### PR TITLE
Implement rudimentary CI workflow, along with some verifiable cleanup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure git environment
+        run: |
+          git config user.name "MIT Libraries"
+          git config user.email engx-lib@mit.edu
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          known_hosts: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
+
+      - name: Add Pantheon remote
+        run: |
+          git remote add pantheon ${{ secrets.PANTHEON_REPOSITORY }}
+
+      - name: Fetch from Pantheon
+        run: |
+          git fetch pantheon
+
+      - name: Git push
+        run: |
+          git push pantheon master

--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ In some circumstances, you may need to specify port numbers as part of the site 
 * Environment variables are managed with [Dotenv](https://github.com/vlucas/phpdotenv).
 * Enhanced security (separated web root and secure passwords with [wp-password-bcrypt](https://github.com/roots/wp-password-bcrypt))
 
+## Required environment and secrets
+
+### Environment variables
+
+This section TBD (see legacy section below)
+
+### Github secrets
+
+For our CI workflow, we have defined the following variables. All values are available in our shared LastPass account.
+
+- `DEPLOY_SSH_KNOWN_HOSTS` The known_hosts file to allow GitHubs' CI to trust the Pantheon git server.
+- `DEPLOY_SSH_PRIVATE_KEY` The private key (with blank passphrase) used to connect to Pantheon's git server. The public key is added to your personal settings within Pantheon.
+- `PANTHEON_REPOSITORY` The SSH-format address of the git repository in Pantheon.
+
 ---
 **The sections below were included in the original Readme, and I'm not sure whether they are still useful in this context.**
 

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
     "wpackagist-plugin/lh-hsts": "^1.25",
     "wpackagist-plugin/pantheon-advanced-page-cache": "^1.0",
     "wpackagist-plugin/wp-native-php-sessions": "^1.2",
-    "wpackagist-plugin/classic-editor": "^1.6"
+    "wpackagist-plugin/classic-editor": "^1.6",
+    "wpackagist-plugin/wp-sentry-integration": "^6.0"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5276f2116b8303c59ec5e13b3f728361",
+    "content-hash": "5b85805636fa418add03c3fe305d607f",
     "packages": [
         {
             "name": "composer/installers",
@@ -1234,6 +1234,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wp-native-php-sessions/"
+        },
+        {
+            "name": "wpackagist-plugin/wp-sentry-integration",
+            "version": "6.0.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-sentry-integration/",
+                "reference": "tags/6.0.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-sentry-integration.6.0.0.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-sentry-integration/"
         },
         {
             "name": "wpackagist-theme/twentytwentytwo",

--- a/web/t.php
+++ b/web/t.php
@@ -1,3 +1,0 @@
-<?php
-
-var_dump($_ENV);


### PR DESCRIPTION
This implements a very rudimentary CI workflow, using GitHub Actions, that should automatically deploy the base branch to Pantheon's Dev tier when a PR merges.

For now, dealing with multidev environments - both their setup and cleanup - are the responsibility of the engineer working on the ticket. Instructions for those processes are being added to the project readme.

Please note - this PR has two visible side effects, included so that we have an application-side confirmation that the deploy happened as expected:
1. The Sentry integration plugin is being added
2. A temporary PHP script that was used for debugging an earlier ticket, which is now able to be removed, is being removed.

## Ticket

https://mitlibraries.atlassian.net/browse/ENGX-198

### Dependencies

YES  dependencies are updated (see side effects above)


## Code Reviewer

_This work is not being reviewed, as it already received code review as part of MITLibraries/mitlib-wp-network-legacy#4 _