### PR TITLE
Resolve URL handling for network dashboard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
     "wpackagist-plugin/wp-native-php-sessions": "^1.2",
     "wpackagist-plugin/classic-editor": "^1.6",
     "wpackagist-plugin/wp-sentry-integration": "^6.0",
-    "wpackagist-plugin/wp-mail-smtp": "^3.6"
+    "wpackagist-plugin/wp-mail-smtp": "^3.6",
+    "roots/multisite-url-fixer": "^1.1"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e9249138efa46b67bedb4e5351f6b3a",
+    "content-hash": "26f27c88dfe09cd9cce9b33fbd456994",
     "packages": [
         {
             "name": "composer/installers",
@@ -521,6 +521,49 @@
                 }
             ],
             "time": "2020-05-20T01:25:07+00:00"
+        },
+        {
+            "name": "roots/multisite-url-fixer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/roots/multisite-url-fixer.git",
+                "reference": "e664180d71b29ae8362261ae3bc772a28eac2308"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/roots/multisite-url-fixer/zipball/e664180d71b29ae8362261ae3bc772a28eac2308",
+                "reference": "e664180d71b29ae8362261ae3bc772a28eac2308",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "squizlabs/php_codesniffer": "^3.1"
+            },
+            "type": "wordpress-muplugin",
+            "autoload": {
+                "psr-4": {
+                    "Roots\\Bedrock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Fixes WordPress issues with home and site URL on multisite when using Bedrock",
+            "homepage": "https://roots.io/bedrock/",
+            "keywords": [
+                "wordpress"
+            ],
+            "support": {
+                "forum": "https://discourse.roots.io/",
+                "issues": "https://github.com/roots/multisite-url-fixer/issues",
+                "source": "https://github.com/roots/multisite-url-fixer/tree/1.1.0"
+            },
+            "abandoned": true,
+            "time": "2017-10-17T21:07:50+00:00"
         },
         {
             "name": "roots/wordpress",


### PR DESCRIPTION
This adds the [Multisite URL Fixer](https://github.com/roots/multisite-url-fixer) package to the application, allowing links to, and within, the network dashboard to function correctly.

A second part of this work, to repair an issue with all sites beyond the first site, is being paused while we wait to see what Pantheon will fix themselves.

## Developer

### Ticket

https://mitlibraries.atlassian.net/browse/ENGX-206
Review app is linked from there

### Secrets

- [x] This change requires no updates to secrets

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated (adding roots/multisite-url-fixer)


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
