### PR TITLE
Adds CMS Tree Page View plugin

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -107,6 +107,11 @@ composer update wpackagist-plugin/hello-dolly
 **Please note:** If the resulting diff from a Composer workflow goes beyond `composer.json` and `composer.lock`, please
 double-check what is being changed. It is likely that something unexpected has happened; proceed with caution.
 
+**Please note:** Our linting rules expect that you will manually exclude third party plugins in our `phpcs.xml` config.
+For example: `<exclude-pattern>web/app/plugins/FOO</exclude-pattern>`. We don't exclude _all_ plugins as we want to
+ensure that our locally developed plugins follow our standards so by default scanning everything and turning off third
+party plugins manually is our practice
+
 #### Adding or updating locally-written code
 
 Locally-developed plugins and themes are, with rare exceptions, added directly to this repository.

--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
     "wpackagist-plugin/cf7-to-zapier": "^2.2",
     "wpackagist-plugin/classic-editor": "^1.6",
     "wpackagist-plugin/classic-widgets": "^0.3.0",
+    "wpackagist-plugin/cms-tree-page-view": "^1.6",
     "wpackagist-plugin/contact-form-7": "^5.6",
     "wpackagist-plugin/custom-post-type-ui": "^1.13",
     "wpackagist-plugin/enable-media-replace": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "621e118ca5c9972a652dfb2ba9051cd7",
+    "content-hash": "8b468f1fa96a7f0532a9ac77f68639ed",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -1414,6 +1414,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/classic-widgets/"
+        },
+        {
+            "name": "wpackagist-plugin/cms-tree-page-view",
+            "version": "1.6.6",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/cms-tree-page-view/",
+                "reference": "tags/1.6.6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/cms-tree-page-view.1.6.6.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/cms-tree-page-view/"
         },
         {
             "name": "wpackagist-plugin/contact-form-7",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -53,6 +53,7 @@
   <exclude-pattern>web/app/plugins/cf7-to-zapier</exclude-pattern>
   <exclude-pattern>web/app/plugins/classic-editor</exclude-pattern>
   <exclude-pattern>web/app/plugins/classic-widgets</exclude-pattern>
+  <exclude-pattern>web/app/plugins/cms-tree-page-view</exclude-pattern>
   <exclude-pattern>web/app/plugins/contact-form-7</exclude-pattern>
   <exclude-pattern>web/app/plugins/custom-post-type-ui</exclude-pattern>
   <exclude-pattern>web/app/plugins/enable-media-replace</exclude-pattern>


### PR DESCRIPTION
Why are these changes being introduced:

* The CMS Tree Page View plugin is part of our standard set of plugins

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/LM-26

Multidev link for this work:

https://mitlib-wp-network.lndo.site/wp/wp-admin/edit.php?post_type=page&page=cms-tpv-page-page

## Developer

### Secrets

- [x] All new secrets have been added to Pantheon tiers
- [x] Relevant secrets have been updated in Github Actions
- [x] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
