### PR TITLE
Add forked plugin, update documentation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -153,6 +153,28 @@ After dependencies are checked out, we run a security-focused check of the codeb
 ```bash
 composer security
 ```
+#### Adding plugins from private repositories
+
+In certain conditions, we need to add plugins which are not distributed via the WordPress plugin directory. In some of
+these cases, the plugin publisher will include documentation about how to deploy their plugin via Composer, in which
+case those instructions should be followed.
+
+When there is no Composer-compliant means of deploying the plugin, however, we can still include those plugins by
+creating a private repository within our organization. The following process should be followed:
+
+1. Create a private repository within the MIT Libraries organization with the plugin code.
+2. If one does not already exist, create a minimal `composer.json` with the type value of `wordpress-plugin`. The
+   package name should be `mitlibraries/plugin-name`, with the original plugin authors named. If a composer file already
+   exists, so long as the type is set correctly no changes should be made - but future references to the plugin should
+   use its existing package name.
+3. Create a release with the same version number that the plugin currently states in its base PHP file.
+4. Add this private repository to the [WordPress team](https://github.com/orgs/MITLibraries/teams/wordpress/repositories) within the Libraries' organization.
+5. Add the private repository URL to the list of repositories within `composer.json`.
+6. Add the plugin itself via `composer require mitlibraries/plugin-name`.
+7. Add the plugin as an exclusion to the `phpcs.xml` file.
+
+The intent behind the WordPress team and its structure are inherited from the Infrastructure group's use of an
+Automation team for their work. [Details about this approach can be found on the Infra wiki.](https://mitlibraries.atlassian.net/wiki/spaces/IN/pages/2888826883/Reference+Terraform+Cloud+and+GitHub+Initial+Configuration)
 
 #### Changing sites on the network
 
@@ -206,6 +228,7 @@ Please see the readme for that project for [installation](https://github.com/pan
 #### Required build secrets
 
 - `ACF_PRO_KEY` - License key necessary for installing the Advanced Custom Fields Pro plugin
+- `github-oauth.github.com` - User access token defined by the `mitlib-wp-network-deploy` account
 
 
 ### Application secrets
@@ -249,7 +272,8 @@ Bedrock makes use of an `.env` file to store environment variables. Pantheon tak
 - `AUTH_KEY`, `SECURE_AUTH_KEY`, `LOGGED_IN_KEY`, `NONCE_KEY`, `AUTH_SALT`, `SECURE_AUTH_SALT`, `LOGGED_IN_SALT`, `NONCE_SALT`
   - Generate with [wp-cli-dotenv-command](https://github.com/aaemnnosttv/wp-cli-dotenv-command)
   - Regenerate with [Bedrock's WordPress salts generator](https://roots.io/salts.html)
-
+- `COMPOSER_AUTH` - The user access token defined by the `mitlib-wp-network-deploy` account, for installing forked
+  plugins
 
 ### Github secrets
 
@@ -258,6 +282,7 @@ Managed with: Github web UI
 In addition to secret values stored using Terminus, we also define certain values used by our CI workflow using Github secrets.
 
 - `ACF_PRO_KEY` License key necessary for installing the Advanced Custom Fields Pro plugin.
+- `COMPOSER_AUTH` The user access token defined by the `mitlib-wp-network-deploy` account, for installing forked plugins.
 - `DEPLOY_SSH_KNOWN_HOSTS` The known_hosts file to allow GitHubs' CI to trust the Pantheon git server.
 - `DEPLOY_SSH_PRIVATE_KEY` The private key (with blank passphrase) used to connect to Pantheon's git server. The public key is added to your personal settings within Pantheon.
 - `PANTHEON_REPOSITORY` The SSH-format address of the git repository in Pantheon.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       run: composer install --no-progress --prefer-dist --optimize-autoloader
       env:
         ACF_PRO_KEY: ${{ secrets.ACF_PRO_KEY }}
+        COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{secrets.COMPOSER_AUTH}}"} }'
 
     - name: Run tests
       run: composer security

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,34 @@
       "url": "https://github.com/matt-bernhardt/WP-SCSS"
     },
     {
+      "type": "vcs",
+      "url": "https://github.com/mitlibraries/acf-location-field"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/mitlibraries/advanced-post-types-order"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/mitlibraries/cpt-onomies"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/mitlibraries/dynamic-menu-manager"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/mitlibraries/lightbox-plus"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/mitlibraries/slideshow-gallery"
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/mitlibraries/wp-slug-trimmer"
+    },
+    {
       "type": "path",
       "url": "upstream-configuration"
     }
@@ -72,6 +100,13 @@
     "composer/installers": "^2.2",
     "connectthink/wp-scss": "^2.4@beta",
     "google/apiclient": "^2.12",
+    "mitlibraries/acf-location-field": "^1.0",
+    "mitlibraries/cpt-onomies": "^1.4",
+    "mitlibraries/dynamic-menu-manager": "^1.0",
+    "mitlibraries/lightbox-plus": "^2.7",
+    "mitlibraries/slideshow-gallery": "dev-main",
+    "mitlibraries/wp-slug-trimmer": "^1.1",
+    "nsp-code/advanced-post-types-order": "^4.4",
     "oscarotero/env": "^2.1",
     "pantheon-systems/pantheon-mu-plugin": "^1.0",
     "pantheon-upstreams/upstream-configuration": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -87,6 +87,10 @@
     },
     {
       "type": "vcs",
+      "url": "https://github.com/mitlibraries/types"
+    },
+    {
+      "type": "vcs",
       "url": "https://github.com/mitlibraries/wp-slug-trimmer"
     },
     {
@@ -105,6 +109,7 @@
     "mitlibraries/dynamic-menu-manager": "^1.0",
     "mitlibraries/lightbox-plus": "^2.7",
     "mitlibraries/slideshow-gallery": "dev-main",
+    "mitlibraries/types": "^2.3",
     "mitlibraries/wp-slug-trimmer": "^1.1",
     "nsp-code/advanced-post-types-order": "^4.4",
     "oscarotero/env": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a16f94c50b098ee0153db47532476214",
+    "content-hash": "614ffb0dc63b16ec736ce5dae8e504db",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -987,6 +987,37 @@
                 "issues": "https://github.com/MITLibraries/slideshow-gallery/issues"
             },
             "time": "2022-12-06T21:58:02+00:00"
+        },
+        {
+            "name": "mitlibraries/types",
+            "version": "2.3.5",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:MITLibraries/types.git",
+                "reference": "c0c5fb8923aaac043d0ba0da39cfe0f0e7eea198"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MITLibraries/types/zipball/c0c5fb8923aaac043d0ba0da39cfe0f0e7eea198",
+                "reference": "c0c5fb8923aaac043d0ba0da39cfe0f0e7eea198",
+                "shasum": ""
+            },
+            "default-branch": true,
+            "type": "wordpress-plugin",
+            "license": [
+                "GPL-2.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "OnTheGoSystems"
+                }
+            ],
+            "description": "Toolset Types defines custom content in WordPress",
+            "support": {
+                "source": "https://github.com/MITLibraries/types/tree/2.3.5",
+                "issues": "https://github.com/MITLibraries/types/issues"
+            },
+            "time": "2022-12-06T21:42:13+00:00"
         },
         {
             "name": "mitlibraries/wp-slug-trimmer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "614ffb0dc63b16ec736ce5dae8e504db",
+    "content-hash": "ead665bab0ac3ab9dc56e0cba2eddc10",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8ecfd974b2930318dcf2c44e77f04da",
+    "content-hash": "a16f94c50b098ee0153db47532476214",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -838,6 +838,191 @@
             "time": "2022-10-26T14:07:24+00:00"
         },
         {
+            "name": "mitlibraries/acf-location-field",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:MITLibraries/acf-location-field.git",
+                "reference": "8f6857fe8331bd0ca608116392c5cee135297fca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MITLibraries/acf-location-field/zipball/8f6857fe8331bd0ca608116392c5cee135297fca",
+                "reference": "8f6857fe8331bd0ca608116392c5cee135297fca",
+                "shasum": ""
+            },
+            "type": "wordpress-plugin",
+            "license": [
+                "GPL-2.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Elliot Condon"
+                }
+            ],
+            "description": "Adds a 'Google Maps' field type for the Advanced Custom Fields WordPress plugin",
+            "support": {
+                "source": "https://github.com/MITLibraries/acf-location-field/tree/1.0.0",
+                "issues": "https://github.com/MITLibraries/acf-location-field/issues"
+            },
+            "time": "2022-12-06T20:22:05+00:00"
+        },
+        {
+            "name": "mitlibraries/cpt-onomies",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:MITLibraries/cpt-onomies.git",
+                "reference": "0f9222a20198525b95bd3d8ed948a941d55e7a1c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MITLibraries/cpt-onomies/zipball/0f9222a20198525b95bd3d8ed948a941d55e7a1c",
+                "reference": "0f9222a20198525b95bd3d8ed948a941d55e7a1c",
+                "shasum": ""
+            },
+            "type": "wordpress-plugin",
+            "license": [
+                "GPL-2.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Dejan Markovic"
+                }
+            ],
+            "description": "Use your custom post types as taxonomies. Create powerful relationships between your posts and, therefore, powerful content",
+            "support": {
+                "source": "https://github.com/MITLibraries/cpt-onomies/tree/1.4.0",
+                "issues": "https://github.com/MITLibraries/cpt-onomies/issues"
+            },
+            "time": "2022-12-06T20:41:52+00:00"
+        },
+        {
+            "name": "mitlibraries/dynamic-menu-manager",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:MITLibraries/dynamic-menu-manager.git",
+                "reference": "7d1e555d4454d5fc21c8cb96f6cd7e03f55c11f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MITLibraries/dynamic-menu-manager/zipball/7d1e555d4454d5fc21c8cb96f6cd7e03f55c11f7",
+                "reference": "7d1e555d4454d5fc21c8cb96f6cd7e03f55c11f7",
+                "shasum": ""
+            },
+            "type": "wordpress-plugin",
+            "license": [
+                "GPL-2.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Duogeek"
+                }
+            ],
+            "description": "Add different wordpress menu in different pages",
+            "support": {
+                "source": "https://github.com/MITLibraries/dynamic-menu-manager/tree/1.0.4",
+                "issues": "https://github.com/MITLibraries/dynamic-menu-manager/issues"
+            },
+            "time": "2022-12-06T20:59:34+00:00"
+        },
+        {
+            "name": "mitlibraries/lightbox-plus",
+            "version": "2.7.2",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:MITLibraries/lightbox-plus.git",
+                "reference": "cc1d91a5e3fd3dc9e79dbdec49352f03ca286b63"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MITLibraries/lightbox-plus/zipball/cc1d91a5e3fd3dc9e79dbdec49352f03ca286b63",
+                "reference": "cc1d91a5e3fd3dc9e79dbdec49352f03ca286b63",
+                "shasum": ""
+            },
+            "type": "wordpress-plugin",
+            "license": [
+                "GPL-2.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Dan Zappone"
+                }
+            ],
+            "description": "Lightbox Plus Colorbox permits users to view larger versions of images, simple slideshows, videos, and content all in an overlay",
+            "support": {
+                "source": "https://github.com/MITLibraries/lightbox-plus/tree/2.7.2",
+                "issues": "https://github.com/MITLibraries/lightbox-plus/issues"
+            },
+            "time": "2022-12-06T21:29:44+00:00"
+        },
+        {
+            "name": "mitlibraries/slideshow-gallery",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:MITLibraries/slideshow-gallery.git",
+                "reference": "8daf9198a68d22843d42950a1329dc3a458367c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MITLibraries/slideshow-gallery/zipball/8daf9198a68d22843d42950a1329dc3a458367c3",
+                "reference": "8daf9198a68d22843d42950a1329dc3a458367c3",
+                "shasum": ""
+            },
+            "default-branch": true,
+            "type": "wordpress-plugin",
+            "license": [
+                "GPL-2.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "Tribulant"
+                }
+            ],
+            "description": "Feature content in a JavaScript powered slideshow gallery showcase on your WordPress website",
+            "support": {
+                "source": "https://github.com/MITLibraries/slideshow-gallery/tree/1.6.12.1-mitlib3",
+                "issues": "https://github.com/MITLibraries/slideshow-gallery/issues"
+            },
+            "time": "2022-12-06T21:58:02+00:00"
+        },
+        {
+            "name": "mitlibraries/wp-slug-trimmer",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:MITLibraries/wp-slug-trimmer.git",
+                "reference": "e6986e66b756007110c3c060f84848082e1c4263"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MITLibraries/wp-slug-trimmer/zipball/e6986e66b756007110c3c060f84848082e1c4263",
+                "reference": "e6986e66b756007110c3c060f84848082e1c4263",
+                "shasum": ""
+            },
+            "type": "wordpress-plugin",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "MIT Libraries",
+                    "email": "engx@mit.edu"
+                },
+                {
+                    "name": "Graeme Pietersz"
+                }
+            ],
+            "description": "A small plugin to allow shorter slugs on posts",
+            "support": {
+                "source": "https://github.com/MITLibraries/wp-slug-trimmer/tree/1.1.1",
+                "issues": "https://github.com/MITLibraries/wp-slug-trimmer/issues"
+            },
+            "time": "2022-12-06T16:06:02+00:00"
+        },
+        {
             "name": "monolog/monolog",
             "version": "2.8.0",
             "source": {
@@ -938,6 +1123,33 @@
                 }
             ],
             "time": "2022-07-24T11:55:47+00:00"
+        },
+        {
+            "name": "nsp-code/advanced-post-types-order",
+            "version": "4.4.3",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:MITLibraries/advanced-post-types-order.git",
+                "reference": "d01675d1cb2aeadf24a5447a5a9206ae2fcd7a9c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MITLibraries/advanced-post-types-order/zipball/d01675d1cb2aeadf24a5447a5a9206ae2fcd7a9c",
+                "reference": "d01675d1cb2aeadf24a5447a5a9206ae2fcd7a9c",
+                "shasum": ""
+            },
+            "type": "wordpress-plugin",
+            "authors": [
+                {
+                    "name": "MIT Libraries"
+                }
+            ],
+            "description": "Order Post Types Objects using a Drag and Drop Sortable javascript capability",
+            "support": {
+                "source": "https://github.com/MITLibraries/advanced-post-types-order/tree/4.4.3",
+                "issues": "https://github.com/MITLibraries/advanced-post-types-order/issues"
+            },
+            "time": "2022-12-02T21:47:20+00:00"
         },
         {
             "name": "oscarotero/env",
@@ -3999,6 +4211,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "connectthink/wp-scss": 10,
+        "mitlibraries/slideshow-gallery": 20,
         "pantheon-upstreams/upstream-configuration": 20,
         "roave/security-advisories": 20
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -43,9 +43,11 @@
   <exclude-pattern>web/app/mu-plugins/pantheon-mu-plugin</exclude-pattern>
   <exclude-pattern>web/app/mu-plugins/bedrock-autoloader.php</exclude-pattern>
   <exclude-pattern>web/app/plugins/acf-image-crop-add-on</exclude-pattern>
+  <exclude-pattern>web/app/plugins/acf-location-field</exclude-pattern>
   <exclude-pattern>web/app/plugins/add-category-to-pages</exclude-pattern>
-  <exclude-pattern>web/app/plugins/advanced-custom-fields-pro</exclude-pattern>
   <exclude-pattern>web/app/plugins/addthis</exclude-pattern>
+  <exclude-pattern>web/app/plugins/advanced-custom-fields-pro</exclude-pattern>
+  <exclude-pattern>web/app/plugins/advanced-post-types-order</exclude-pattern>
   <exclude-pattern>web/app/plugins/akismet</exclude-pattern>
   <exclude-pattern>web/app/plugins/antivirus</exclude-pattern>
   <exclude-pattern>web/app/plugins/black-studio-tinymce-widget</exclude-pattern>
@@ -55,11 +57,14 @@
   <exclude-pattern>web/app/plugins/classic-widgets</exclude-pattern>
   <exclude-pattern>web/app/plugins/cms-tree-page-view</exclude-pattern>
   <exclude-pattern>web/app/plugins/contact-form-7</exclude-pattern>
+  <exclude-pattern>web/app/plugins/cpt-onomies</exclude-pattern>
   <exclude-pattern>web/app/plugins/custom-post-type-ui</exclude-pattern>
+  <exclude-pattern>web/app/plugins/dynamic-menu-manager</exclude-pattern>
   <exclude-pattern>web/app/plugins/enable-media-replace</exclude-pattern>
   <exclude-pattern>web/app/plugins/filter-page-by-template</exclude-pattern>
   <exclude-pattern>web/app/plugins/google-sitemap-generator</exclude-pattern>
   <exclude-pattern>web/app/plugins/lh-hsts</exclude-pattern>
+  <exclude-pattern>web/app/plugins/lightbox-plus</exclude-pattern>
   <exclude-pattern>web/app/plugins/media-library-assistant</exclude-pattern>
   <exclude-pattern>web/app/plugins/notification</exclude-pattern>
   <exclude-pattern>web/app/plugins/page-links-to</exclude-pattern>
@@ -80,6 +85,7 @@
   <exclude-pattern>web/app/plugins/WP-SCSS</exclude-pattern>
   <exclude-pattern>web/app/plugins/wp-security-audit-log</exclude-pattern>
   <exclude-pattern>web/app/plugins/wp-sentry-integration</exclude-pattern>
+  <exclude-pattern>web/app/plugins/wp-slug-trimmer</exclude-pattern>
   <exclude-pattern>web/app/plugins/wpcf7-recaptcha</exclude-pattern>
   <exclude-pattern>web/private/*</exclude-pattern>
   <!-- End Pantheon addition -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -75,6 +75,7 @@
   <exclude-pattern>web/app/plugins/slideshow-gallery</exclude-pattern>
   <exclude-pattern>web/app/plugins/tablepress</exclude-pattern>
   <exclude-pattern>web/app/plugins/tinymce-advanced</exclude-pattern>
+  <exclude-pattern>web/app/plugins/types</exclude-pattern>
   <exclude-pattern>web/app/plugins/ultimate-posts-widget</exclude-pattern>
   <exclude-pattern>web/app/plugins/widget-context</exclude-pattern>
   <exclude-pattern>web/app/plugins/widget-css-classes</exclude-pattern>


### PR DESCRIPTION
This adds the forked plugins to the application, completing the build out of plugins (huzzah!). This includes the abandoned plugins which are no longer available from the directory, as well as the one purchased plugin which has no Composer-compliant distribution channel.

I've added a section to the docs about how to add this type of plugin in the future, and included a link to the Infra wiki describing their teams-based approach for access to private repos.

The token values you should need to get this working locally should be found in LastPass. 

## Developer

### Secrets

- [x] All new secrets have been added to Pantheon tiers
- [x] Relevant secrets have been updated in Github Actions
- [x] All new secrets documented in README

### Documentation

- [x] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
