### PR TITLE
Adds field group for Alert records, updates theme to support

### DIFF
--- a/web/app/mu-plugins/mitlib-post/data/group_58e229318a751.json
+++ b/web/app/mu-plugins/mitlib-post/data/group_58e229318a751.json
@@ -1,0 +1,98 @@
+{
+    "key": "group_58e229318a751",
+    "title": "Alerts",
+    "fields": [
+        {
+            "key": "field_51a21249841dd",
+            "label": "Alert",
+            "name": "alert",
+            "type": "true_false",
+            "instructions": "This is an alert-level post.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_54495c5677eae",
+            "label": "Confirm alert",
+            "name": "confirm_alert",
+            "type": "true_false",
+            "instructions": "Alert posts appear at the top of ALL pages. Please confirm that this is an alert-level post.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_51a21249841dd",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_54495c8077eaf",
+            "label": "Closable",
+            "name": "closable",
+            "type": "true_false",
+            "instructions": "Allow users to close this alert. Once closed, the alert will not be show again for that particular user.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_51a21249841dd",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 1,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "post"
+            }
+        ]
+    ],
+    "menu_order": 6,
+    "position": "acf_after_title",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "show_in_rest": 0,
+    "modified": 1671735420
+}

--- a/web/app/themes/mitlib-parent/functions.php
+++ b/web/app/themes/mitlib-parent/functions.php
@@ -229,6 +229,30 @@ function get_root( $post ) {
 }
 
 /**
+ * Adds custom fields to 'post' and 'experts' API endpoints
+ *
+ * @link http://v2.wp-api.org/extending/modifying/
+ * @link https://gist.github.com/rileypaulsen/9b4505cdd0ac88d5ef51#gistcomment-1622466
+ */
+function mitlib_api_alter() {
+	// Add custom fields to posts endpoint.
+	register_rest_field( 'post',
+		'meta',
+		array(
+			'get_callback'    => function( $data, $field, $request, $type ) {
+				if ( function_exists( 'get_fields' ) ) {
+					return get_fields( $data['id'] );
+				}
+				return array();
+			},
+			'update_callback' => null,
+			'schema'          => null,
+		)
+	);
+}
+add_action( 'rest_api_init', 'Mitlib\Parent\mitlib_api_alter' );
+
+/**
  * Registers our main widget areas.
  */
 function mitlib_sidebars_init() {


### PR DESCRIPTION
This adds the field group which allows Post records to function as system alerts, and updates the theme to make these fields appear in the expected place within the WP API.

*Please note* - the theme function causes these fields to appear in the `meta` block of the record in the API, which is where our current code expects it. There is a built-in feature of ACF which, if enabled, instead places these fields in an `acf` block of the API - which is unexpected, and would require code changes within `js/alerts.js` to support. I've elected to preserve our existing setup out of concern of cascading changes elsewhere if we change the API response.

## Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/lm-14 (this ticket has a link to a reference page in the review app which shows the Alerts working).

It should also be possible to pull this code locally, create a new Post record, and see the fields appear when creating a Post record. Checking all the boxes and then loading a page should result in the alert appearing.

![Screen Shot 2022-12-22 at 3 50 51 PM](https://user-images.githubusercontent.com/1403248/209223682-1b5102bc-3bd1-4283-afe2-b80ccb8871c1.png)

### Document any side effects to this change:

Choosing to put the function in the parent theme feels awkward, as for other custom post types we've put this function in the class defining the content type. However, without a separate post type for Alerts, adding this to the theme is kind of the only option.

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are changed in this work

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
