### PR TITLE
Resolve or whitelist content escaping problems

### DIFF
--- a/web/app/themes/mitlib-child/inc/breadcrumbs-child.php
+++ b/web/app/themes/mitlib-child/inc/breadcrumbs-child.php
@@ -9,6 +9,6 @@
 ?>
 <div class="betterBreadcrumbs hidden-phone" role="navigation" aria-label="breadcrumbs">
 	<span><a href="/">Libraries home</a></span>
-	<span><a href="<?php echo home_url(); ?>"><?php bloginfo(); ?></a></span>
+	<span><a href="<?php echo esc_url( home_url() ); ?>"><?php bloginfo(); ?></a></span>
 	<?php betterChildBreadcrumbs(); ?>
 </div>

--- a/web/app/themes/mitlib-child/inc/content-front.php
+++ b/web/app/themes/mitlib-child/inc/content-front.php
@@ -42,7 +42,7 @@ if ( count( $sticky ) > 0 ) {
 			<img class="excerpt-post__fig" src="<?php echo esc_attr( get_first_post_image() ); ?>" width="200" >
 			<?php endif; ?>
 			<div class="excerpt-post__body">
-				<h3><a href="<?php echo the_permalink(); ?>"><?php echo get_the_title(); ?></a></h3>
+				<h3><a href="<?php echo esc_url( the_permalink() ); ?>"><?php the_title(); ?></a></h3>
 				<?php custom_excerpt( 20, '...' ); ?>
 			</div>
 		</div>

--- a/web/app/themes/mitlib-child/sidebar.php
+++ b/web/app/themes/mitlib-child/sidebar.php
@@ -16,24 +16,7 @@
 
 			dynamic_sidebar( 'sidebar' );
 
-			// Show Login/Logout for News blog.
-			$blogName = get_bloginfo( 'name' );
-		if ( 'MIT Libraries News' === $blogName ) :
-
-			?>
-
-			<aside class="widget admin">
-				<h2>Admin</h2>
-			<?php
-			if ( is_user_logged_in( 1 ) ) {
-				echo '<span><a href="' . wp_logout_url() . '">Log out</a></span>';
-			} else {
-				echo '<span><a href="' . wp_login_url() . '">Log in</a></span>';
-			}
-			?>
-			</aside>
-
-		<?php endif; ?>
+		?>
 
 	</div><!-- #secondary -->
 

--- a/web/app/themes/mitlib-child/upw/child-exhibits.php
+++ b/web/app/themes/mitlib-child/upw/child-exhibits.php
@@ -12,7 +12,11 @@
 
 <?php if ( $instance['before_posts'] ) : ?>
   <div class="upw-before">
-	<?php echo wpautop( $instance['before_posts'] ); ?>
+	<?php
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- wpautop likely needs wp_kses to allow paragraphs.
+		echo wpautop( $instance['before_posts'] );
+		// phpcs:enable -- resume normal scanning.
+	?>
   </div>
 <?php endif; ?>
 
@@ -39,7 +43,7 @@
 				<div class="entry-cats-list">
 				<?php
 				foreach ( ( get_the_category() ) as $category ) {
-					echo '<span class="category-bg"><span class="category-init">' . ( substr( $category->cat_name, 0, 1 ) ) . '</span></span>' . '<span class="catName">' . $category->cat_name . ' Exhibit' . '</span> ';
+					echo '<span class="category-bg"><span class="category-init">' . esc_html( substr( $category->cat_name, 0, 1 ) ) . '</span></span>' . '<span class="catName">' . esc_html( $category->cat_name ) . ' Exhibit' . '</span> ';
 				}
 				?>
 				</div>
@@ -73,9 +77,13 @@
 			<?php if ( $instance['show_excerpt'] ) : ?>
 			<div class="entry-summary">
 			  <p>
-				<?php echo get_the_excerpt(); ?>
+				<?php
+					// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- excerpt will likely contain markup, needs wp_kses.
+					echo get_the_excerpt();
+					// phpcs:enable -- resume normal scanning.
+				?>
 				<?php if ( $instance['show_readmore'] ) : ?>
-				  <a href="<?php the_permalink(); ?>" class="more-link"><?php echo $instance['excerpt_readmore']; ?></a>
+				  <a href="<?php the_permalink(); ?>" class="more-link"><?php echo esc_html( $instance['excerpt_readmore'] ); ?></a>
 				<?php endif; ?>
 			  </p>
 			</div>
@@ -94,7 +102,7 @@
 					$custom_field_values = get_post_meta( $post->ID, $name, true );
 					if ( $custom_field_values ) :
 						?>
-					<span class="custom-field custom-field-<?php echo $name; ?>">
+					<span class="custom-field custom-field-<?php echo esc_attr( $name ); ?>">
 						<?php
 						if ( ! is_array( $custom_field_values ) ) {
 
@@ -109,7 +117,7 @@
 							if ( 'end_date' === $name ) {
 								?>
 						   <div class="exhibit-ends">
-								<?php echo 'Ends ' . $custom_field_values; } ?>
+								<?php echo 'Ends ' . esc_html( $custom_field_values ); } ?>
 						   </div>
 					  
 							<?php
@@ -117,7 +125,7 @@
 						} else {
 							$last_value = end( $custom_field_values );
 							foreach ( $custom_field_values as $value ) {
-								echo $value;
+								echo esc_html( $value );
 								if ( $value != $last_value ) {
 									echo ' , '; }
 							}
@@ -142,7 +150,7 @@
   <?php else : ?>
 
 	<p class="upw-not-found">
-	  <?php _e( 'No posts found.', 'upw' ); ?>
+	  <?php esc_html_e( 'No posts found.', 'upw' ); ?>
 	</p>
 
   <?php endif; ?>
@@ -151,6 +159,10 @@
 
 <?php if ( $instance['after_posts'] ) : ?>
   <div class="upw-after">
-	<?php echo wpautop( $instance['after_posts'] ); ?>
+	<?php
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- wpautop likely needs wp_kses to allow paragraphs.
+		echo wpautop( $instance['after_posts'] );
+		// phpcs:enable -- resume normal scanning.
+	?>
   </div>
 <?php endif; ?>

--- a/web/app/themes/mitlib-child/upw/child-posts.php
+++ b/web/app/themes/mitlib-child/upw/child-posts.php
@@ -10,7 +10,11 @@
 
 <?php if ( $instance['before_posts'] ) : ?>
   <div class="upw-before">
-	<?php echo wpautop( $instance['before_posts'] ); ?>
+	<?php
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- wpautop likely needs wp_kses to allow paragraphs.
+		echo wpautop( $instance['before_posts'] );
+		// phpcs:enable -- resume normal scanning.
+	?>
   </div>
 <?php endif; ?>
 
@@ -50,7 +54,7 @@
 					$custom_field_values = get_post_meta( $post->ID, $name, true );
 					if ( $custom_field_values ) :
 						?>
-					<span class="custom-field custom-field-<?php echo $name; ?>">
+					<span class="custom-field custom-field-<?php echo esc_attr( $name ); ?>">
 						<?php
 						if ( ! is_array( $custom_field_values ) ) {
 
@@ -62,12 +66,12 @@
 								$custom_field_values = date( 'F j, Y', mktime( 0, 0, 0, $event_date['month'], $event_date['day'], $event_date['year'] ) );
 							}
 
-							echo $custom_field_values;
+							echo esc_html( $custom_field_values );
 
 						} else {
 							$last_value = end( $custom_field_values );
 							foreach ( $custom_field_values as $value ) {
-								echo $value;
+								echo esc_html( $value );
 								if ( $value != $last_value ) {
 									echo ', '; }
 							}
@@ -85,12 +89,16 @@
 			<?php if ( $instance['show_excerpt'] ) : ?>
 			<div class="entry-summary">
 				<?php if ( get_first_post_image() ) : ?>
-				<img src="<?php echo get_first_post_image(); ?>" width="200" >
+				<img src="<?php echo esc_url( get_first_post_image() ); ?>" width="200" >
 				<?php endif; ?>
 			  <p>
-				<?php echo get_the_excerpt(); ?>
+				<?php
+					// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- excerpt will likely contain markup, needs wp_kses.
+					echo get_the_excerpt();
+					// phpcs:enable -- resume normal scanning.
+				?>
 				<?php if ( $instance['show_readmore'] ) : ?>
-				  <a href="<?php the_permalink(); ?>" class="more-link"><?php echo $instance['excerpt_readmore']; ?></a>
+				  <a href="<?php the_permalink(); ?>" class="more-link"><?php echo esc_html( $instance['excerpt_readmore'] ); ?></a>
 				<?php endif; ?>
 			  </p>
 			</div>
@@ -107,24 +115,24 @@
 						<?php if ( $instance['show_date'] || $instance['show_author'] || $instance['show_comments'] ) : ?>
 
 							<?php if ( $instance['show_date'] ) : ?>
-								<time class="published" datetime="<?php echo get_the_time( 'c' ); ?>"><?php echo get_the_time( $instance['date_format'] ); ?></time>
+								<time class="published" datetime="<?php echo esc_attr( get_the_time( 'c' ) ); ?>"><?php echo esc_html( get_the_time( $instance['date_format'] ) ); ?></time>
 							<?php endif; ?>
 
 							<?php if ( $instance['show_date'] && $instance['show_author'] ) : ?>
-								<span class="sep"><?php _e( '|', 'upw' ); ?></span>
+								<span class="sep"><?php esc_html_e( '|', 'upw' ); ?></span>
 							<?php endif; ?>
 
 							<?php if ( $instance['show_author'] ) : ?>
 								<span class="author vcard">
-								<?php echo __( 'By', 'upw' ); ?>
-									<a href="<?php echo get_author_posts_url( get_the_author_meta( 'ID' ) ); ?>" rel="author" class="fn">
+								<?php esc_html_e( 'By', 'upw' ); ?>
+									<a href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author" class="fn">
 									<?php echo get_the_author(); ?>
 									</a>
 								</span>
 							<?php endif; ?>
 
 							<?php if ( $instance['show_author'] && $instance['show_comments'] ) : ?>
-								<span class="sep"><?php _e( '|', 'upw' ); ?></span>
+								<span class="sep"><?php esc_html_e( '|', 'upw' ); ?></span>
 							<?php endif; ?>
 
 							<?php if ( $instance['show_comments'] ) : ?>
@@ -152,8 +160,8 @@
 			if ( $instance['show_tags'] && $tags ) :
 				?>
 			  <div class="entry-tags">
-				<strong class="entry-tags-label"><?php _e( 'Tagged', 'upw' ); ?>:</strong>
-				<span class="entry-tags-list"><?php echo $tags; ?></span>
+				<strong class="entry-tags-label"><?php esc_html_e( 'Tagged', 'upw' ); ?>:</strong>
+				<span class="entry-tags-list"><?php echo get_the_term_list( $post->ID, 'post_tag', '', ', ' ); ?></span>
 			  </div>
 			<?php endif; ?>
 
@@ -168,7 +176,7 @@
   <?php else : ?>
 
 	<p class="upw-not-found">
-	  <?php _e( 'No posts found.', 'upw' ); ?>
+	  <?php esc_html_e( 'No posts found.', 'upw' ); ?>
 	</p>
 
   <?php endif; ?>
@@ -177,6 +185,10 @@
 
 <?php if ( $instance['after_posts'] ) : ?>
   <div class="upw-after">
-	<?php echo wpautop( $instance['after_posts'] ); ?>
+	<?php
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- wpautop likely needs wp_kses to allow paragraphs.
+		echo wpautop( $instance['after_posts'] );
+		// phpcs:enable -- resume normal scanning.
+	?>
   </div>
 <?php endif; ?>


### PR DESCRIPTION
## Why are these changes being introduced:

There are a handful of templates in the child theme which violate WordPress' standards when it comes to escaping content. Those violations cause GitHub Actions to fail on its security check, which can mask other problems being introduced during development.

## Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/lm-142

## How does this address that need:

Any line flagged by GitHub Actions (which is running the security-focused PHPCS config file internally) is either fixed, or whitelisted because the actual fix is going to be more complex than "add a function here".

In one case - `sidebar.php` - the offending lines are part of a block of code that shouldn't be there. The child theme isn't used for the News theme in our site, and having links to the login/logout page are not a great idea in the first place. I've elected to remove the entire block for both of these reasons.

Finally, the proof of the solution is that GitHub Actions is now passing on this PR.

## Document any side effects to this change:

There are two side effects:

1. A handful of lines are being ignored, rather than fixed properly. We repeated the same step with the parent theme, and will need to return to these lines at some point. To find the list of ignored lines, you can search the codebase for the `phpcs:disable` string.

2. The technique we are using to whitelist lines from PHPCS in GitHub Actions is not recognized by CodeClimate - so there are still violations being flagged there for those lines. I've looked into how to get CodeClimate to respect the `phpcs:disable` directive, but have come up empty so far. The hope was switching to the beta channel (get use the same version of PHPCS that I use locally) would resolve this, but PHPCS just throws errors on that channel at this point. I'm happy to pair / discuss this further during review if you'd like, maybe I missed something.

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No new secrets are defined

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
