### PR TITLE
Updated whitelist for navwalker library

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -17,4 +17,5 @@ ratings:
   - "**.js"
   - "**.php"
 exclude_paths:
+  - web/app/themes/mitlib-child/navwalker.php
   - web/app/themes/mitlib-parent/navwalker.php

--- a/phpcs.security.xml
+++ b/phpcs.security.xml
@@ -2,9 +2,6 @@
 <ruleset name="WordPress Security Standards">
   <description>WordPress Security Standards</description>
 
-  <!-- Exclude files which should not be scanned by PHPCS -->
-  <exclude-pattern>/web/app/themes/mitlib-parent/navwalker.php</exclude-pattern>
-
   <!-- Use the main phpcs.xml as a base, but restrict to security checks -->
   <rule ref="phpcs.xml">
     <!-- Exclude non-security sniffs -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,6 +8,10 @@
   <!-- Scan only PHP files -->
   <arg name="extensions" value="php"/>
 
+  <!-- Exclude files which should not be scanned by PHPCS -->
+  <exclude-pattern>/web/app/themes/mitlib-child/navwalker.php</exclude-pattern>
+  <exclude-pattern>/web/app/themes/mitlib-parent/navwalker.php</exclude-pattern>
+
   <!-- Ignore WordPress and Composer dependencies -->
   <exclude-pattern>config/</exclude-pattern>
   <exclude-pattern>upstream-configuration/</exclude-pattern>


### PR DESCRIPTION
This extends our whitelisting of the Navwalker library in the parent theme to also include the copy of Navwalker in the child theme.

How we implement that whitelist in PHPCS is altered, moving the exclusion from the security-specific config to the more general config file.

We still have LM-162 in the backlog, which will try and convert this file to something managed by Composer. That would take both copies of the file out of this repo, and hopefully allow us to upgrade the version as well.

## Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-142

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No new secrets are defined

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
