### PR TITLE
Standardize file comment tags, add namespaces

### DIFF
--- a/web/app/themes/mitlib-child/archive.php
+++ b/web/app/themes/mitlib-child/archive.php
@@ -4,9 +4,11 @@
  *
  * Learn more: http://codex.wordpress.org/Template_Hierarchy
  *
- * @package MIT_Libraries_Child
- * @since 2.2.2
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' ); ?>
 

--- a/web/app/themes/mitlib-child/category-maihaugen-gallery.php
+++ b/web/app/themes/mitlib-child/category-maihaugen-gallery.php
@@ -2,9 +2,11 @@
 /**
  * The template for displaying Category pages for Maihaugen Gallery on Exhibits site.
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header();
 ?>

--- a/web/app/themes/mitlib-child/category-rotch-library.php
+++ b/web/app/themes/mitlib-child/category-rotch-library.php
@@ -2,9 +2,11 @@
 /**
  * The template for displaying Category pages for Rotch Library on Exhibits site.
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header();
 ?>

--- a/web/app/themes/mitlib-child/category.php
+++ b/web/app/themes/mitlib-child/category.php
@@ -4,9 +4,11 @@
  *
  * Learn more: http://codex.wordpress.org/Template_Hierarchy
  *
- * @package MIT_Libraries_Child
- * @since 2.2.2
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 /**
  * Use the theme archive template

--- a/web/app/themes/mitlib-child/header-child.php
+++ b/web/app/themes/mitlib-child/header-child.php
@@ -4,9 +4,11 @@
  *
  * Displays all of the <head> section and everything up till div#breadcrumb
  *
- * @package MIT_Libraries_Parent
- * @since 1.2.1
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?>
 <?php

--- a/web/app/themes/mitlib-child/header-slim.php
+++ b/web/app/themes/mitlib-child/header-slim.php
@@ -4,9 +4,11 @@
  *
  * Displays all of the <head> section and everything up till div#breadcrumb
  *
- * @package MIT_Libraries_Parent
- * @since 1.2.1
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?><!DOCTYPE html>
 <!--[if lte IE 9]><html class="no-js lte-ie9" lang="en"><![endif]-->

--- a/web/app/themes/mitlib-child/inc/breadcrumbs-category.php
+++ b/web/app/themes/mitlib-child/inc/breadcrumbs-category.php
@@ -2,9 +2,11 @@
 /**
  * Breadcrumb template for internal (non-front) pages.
  *
- * @package MIT_Libraries_Child
- * @since 2.2.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?>
 <div class="betterBreadcrumbs hidden-phone" role="navigation" aria-label="breadcrumbs">

--- a/web/app/themes/mitlib-child/inc/breadcrumbs-child.php
+++ b/web/app/themes/mitlib-child/inc/breadcrumbs-child.php
@@ -2,9 +2,11 @@
 /**
  * Breadcrumb template for internal (non-front) pages.
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?>
 <div class="betterBreadcrumbs hidden-phone" role="navigation" aria-label="breadcrumbs">

--- a/web/app/themes/mitlib-child/inc/breadcrumbs-sitename.php
+++ b/web/app/themes/mitlib-child/inc/breadcrumbs-sitename.php
@@ -2,9 +2,11 @@
 /**
  * Breadcrumb template for front-pages of sites.
  *
- * @package MIT_Libraries_Child
- * @since 1.2.1
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?>
 <div class="betterBreadcrumbs hidden-phone" role="navigation" aria-label="breadcrumbs">

--- a/web/app/themes/mitlib-child/inc/content-feed.php
+++ b/web/app/themes/mitlib-child/inc/content-feed.php
@@ -2,9 +2,11 @@
 /**
  * The template used for displaying a feed of posts
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 2.2.2
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?>
 <div id="sticky-posts-2" class="widget-1 widget-first widget-last widget-odd hide-title widget widget_ultimate_posts" role="complementary">

--- a/web/app/themes/mitlib-child/inc/content-front.php
+++ b/web/app/themes/mitlib-child/inc/content-front.php
@@ -2,9 +2,11 @@
 /**
  * The template used for displaying page content in page-front.php
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 global $isRoot;
 ?>

--- a/web/app/themes/mitlib-child/inc/content-page.php
+++ b/web/app/themes/mitlib-child/inc/content-page.php
@@ -2,9 +2,11 @@
 /**
  * The template used for displaying page content in page.php
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?>
 

--- a/web/app/themes/mitlib-child/inc/content-snippet.php
+++ b/web/app/themes/mitlib-child/inc/content-snippet.php
@@ -2,9 +2,11 @@
 /**
  * The template used for displaying search results in search.php
  *
- * @package MIT_Libraries_Child
- * @since 2.2.2
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?>
 

--- a/web/app/themes/mitlib-child/inc/content-widgetized.php
+++ b/web/app/themes/mitlib-child/inc/content-widgetized.php
@@ -2,9 +2,11 @@
 /**
  * The template used for displaying page content for Widgetized Page
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 global $isRoot;
 ?>

--- a/web/app/themes/mitlib-child/inc/exhibits-current.php
+++ b/web/app/themes/mitlib-child/inc/exhibits-current.php
@@ -4,9 +4,11 @@
  * category-rotch-library.php and category-maihaugen-gallery.php for
  * displaying Current Exhibits.
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 global $isRoot;
 

--- a/web/app/themes/mitlib-child/inc/exhibits-detail.php
+++ b/web/app/themes/mitlib-child/inc/exhibits-detail.php
@@ -4,9 +4,11 @@
  * category-rotch-library.php and category-maihaugen-gallery.php for
  * displaying Current Exhibits.
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 $location_info = get_exhibit_location();
 ?>

--- a/web/app/themes/mitlib-child/inc/exhibits-past.php
+++ b/web/app/themes/mitlib-child/inc/exhibits-past.php
@@ -3,9 +3,11 @@
  * The sub-template used by page-exhibits-feed.php, category-rotch-library.php
  * and category-maihaugen-gallery.php for displaying Past Exhibits.
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 global $isRoot;
 

--- a/web/app/themes/mitlib-child/inc/exhibits-upcoming.php
+++ b/web/app/themes/mitlib-child/inc/exhibits-upcoming.php
@@ -3,9 +3,11 @@
  * The sub-template used by page-exhibits-feed.php, category-rotch-library.php
  * and category-maihaugen-gallery.php for displaying Past Exhibits.
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 global $isRoot;
 

--- a/web/app/themes/mitlib-child/inc/header-image.php
+++ b/web/app/themes/mitlib-child/inc/header-image.php
@@ -2,9 +2,11 @@
 /**
  * This is the template the loads the relevant hero image.
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 // Hero images use a different class on site homepages.
 $hero_class = 'header-bg-image-short';

--- a/web/app/themes/mitlib-child/inc/location.php
+++ b/web/app/themes/mitlib-child/inc/location.php
@@ -2,9 +2,11 @@
 /**
  * The template for displaying location information for Doc Services.
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 $docs = get_post( 1028 );
 $docs_phone = get_post_meta( 1028, 'phone', true );

--- a/web/app/themes/mitlib-child/inc/nav-child.php
+++ b/web/app/themes/mitlib-child/inc/nav-child.php
@@ -2,9 +2,11 @@
 /**
  * The template for displaying the child navigation bar.
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 	$siteName = get_bloginfo( 'name' );
 	$noChildNav = array( 'MIT Libraries News', 'Document Services' );

--- a/web/app/themes/mitlib-child/inc/post-trimmed.php
+++ b/web/app/themes/mitlib-child/inc/post-trimmed.php
@@ -2,9 +2,11 @@
 /**
  * The template for displaying a trimmed post.
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?>
 

--- a/web/app/themes/mitlib-child/inc/postHead.php
+++ b/web/app/themes/mitlib-child/inc/postHead.php
@@ -2,9 +2,11 @@
 /**
  * The template for displaying a post header.
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?>
 <div class="header-section group 

--- a/web/app/themes/mitlib-child/index.php
+++ b/web/app/themes/mitlib-child/index.php
@@ -3,9 +3,11 @@
  *
  * This is the template that displays the news page
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' ); ?>
 

--- a/web/app/themes/mitlib-child/search.php
+++ b/web/app/themes/mitlib-child/search.php
@@ -2,9 +2,11 @@
 /**
  * The template for displaying Search Results pages.
  *
- * @package MIT_Libraries_Child
- * @since 2.2.2
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' ); ?>
 

--- a/web/app/themes/mitlib-child/sidebar-two.php
+++ b/web/app/themes/mitlib-child/sidebar-two.php
@@ -2,9 +2,11 @@
 /**
  * The sidebar template that controls the widgetized area below content.
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?>
 	

--- a/web/app/themes/mitlib-child/sidebar.php
+++ b/web/app/themes/mitlib-child/sidebar.php
@@ -2,9 +2,11 @@
 /**
  * The Sidebar containing the primary and secondary widget areas.
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?>
 	

--- a/web/app/themes/mitlib-child/single-exhibits.php
+++ b/web/app/themes/mitlib-child/single-exhibits.php
@@ -3,9 +3,11 @@
  *
  * This is the template that displays single posts
  *
- * @package MIT_Libraries_Child
- * @since 2.1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' );
 

--- a/web/app/themes/mitlib-child/single.php
+++ b/web/app/themes/mitlib-child/single.php
@@ -3,9 +3,11 @@
  *
  * This is the template that displays single posts
  *
- * @package MIT_Libraries_Child
- * @since 2.1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' );
 

--- a/web/app/themes/mitlib-child/style.css
+++ b/web/app/themes/mitlib-child/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib Child
 Author: MIT Libraries
-Version: 0.0.1
+Version: 0.1.0
 Description: A child theme of the MIT Libraries' parent, focused on sites built primarily with static pages.
 Template: mitlib-parent
 

--- a/web/app/themes/mitlib-child/tag.php
+++ b/web/app/themes/mitlib-child/tag.php
@@ -4,9 +4,11 @@
  *
  * Learn more: http://codex.wordpress.org/Template_Hierarchy
  *
- * @package MIT_Libraries_Child
- * @since 2.2.2
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 /**
  * Use the theme archive template

--- a/web/app/themes/mitlib-child/templates/page-exhibits-feed.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-feed.php
@@ -2,9 +2,11 @@
 /**
  * Template Name: Exhibits | Current, Upcoming & Past
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' );
 ?>

--- a/web/app/themes/mitlib-child/templates/page-exhibits-home.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-home.php
@@ -3,11 +3,11 @@
  * Template Name: Exhibits | Home Page
  * Used to display archive-type pages for posts in a category.
  *
- * Learn more: http://codex.wordpress.org/Template_Hierarchy
- *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' ); ?>
 

--- a/web/app/themes/mitlib-child/templates/page-exhibits-location.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-location.php
@@ -2,9 +2,6 @@
 /**
  * Template Name: Exhibits | Location Index
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
- *
  * This template displays relevant exhibits for a given location, specified
  * in page content by assigning the page to a given category.
  *
@@ -17,7 +14,12 @@
  *    returned by get_the_category() will be used.
  * 3. Set the Page to display using this page template.
  * 4. The page will now show Exhibit records which share the same category.
+ *
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' );
 

--- a/web/app/themes/mitlib-child/templates/page-exhibits-maihaugen-gallery.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-maihaugen-gallery.php
@@ -2,9 +2,11 @@
 /**
  * Template Name: Exhibits |  Maihaugen Gallery
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' );
 ?>

--- a/web/app/themes/mitlib-child/templates/page-exhibits-past.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-past.php
@@ -2,9 +2,11 @@
 /**
  * Template Name: Exhibits |  Past
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 	get_header( 'child' );
 ?>

--- a/web/app/themes/mitlib-child/templates/page-exhibits-rotch-library.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-rotch-library.php
@@ -2,9 +2,11 @@
 /**
  * Template Name: Exhibits |  Rotch Library
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' );
 ?>

--- a/web/app/themes/mitlib-child/templates/page-front.php
+++ b/web/app/themes/mitlib-child/templates/page-front.php
@@ -7,9 +7,11 @@
  * and that other 'pages' on your WordPress site will use a
  * different template.
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' ); ?>
 

--- a/web/app/themes/mitlib-child/templates/page-full-width.php
+++ b/web/app/themes/mitlib-child/templates/page-full-width.php
@@ -2,10 +2,11 @@
 /**
  * Template Name: Full Width
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
- * @link https://codex.wordpress.org/Template_Hierarchy
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' );
 

--- a/web/app/themes/mitlib-child/templates/page-posts-feed.php
+++ b/web/app/themes/mitlib-child/templates/page-posts-feed.php
@@ -7,9 +7,11 @@
  * and that other 'pages' on your WordPress site will use a
  * different template.
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 2.2.2
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 $pageRoot = getRoot( $post );
 $section = get_post( $pageRoot );

--- a/web/app/themes/mitlib-child/templates/page-widgetized.php
+++ b/web/app/themes/mitlib-child/templates/page-widgetized.php
@@ -7,9 +7,11 @@
  * and that other 'pages' on your WordPress site will use a
  * different template.
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 $pageRoot = getRoot( $post );
 $section = get_post( $pageRoot );

--- a/web/app/themes/mitlib-child/templates/page.php
+++ b/web/app/themes/mitlib-child/templates/page.php
@@ -7,9 +7,11 @@
  * and that other 'pages' on your WordPress site will use a
  * different template.
  *
- * @package MIT_Libraries_Child
- * @since Twenty Twelve 1.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 get_header( 'child' ); ?>
 

--- a/web/app/themes/mitlib-child/upw/child-exhibits.php
+++ b/web/app/themes/mitlib-child/upw/child-exhibits.php
@@ -2,9 +2,11 @@
 /**
  * Custom template to display Exhibit post excerpts when using ultimate posts widget
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 	$exhibitThumb = get_field( 'exhibit_thumbnail_image' );
 

--- a/web/app/themes/mitlib-child/upw/child-posts.php
+++ b/web/app/themes/mitlib-child/upw/child-posts.php
@@ -2,9 +2,11 @@
 /**
  * Custom template to display post excerpts when using ultimate posts widget
  *
- * @package MIT_Libraries_Child
- * @since 2.0.0
+ * @package MITlib_Child
+ * @since 0.1.0
  */
+
+namespace Mitlib\Child;
 
 ?>
 


### PR DESCRIPTION
## Why are these changes being introduced:

* The copy-pasted files from the legacy repo still had the old package name, and now-inaccurate since values.
* Additionally, these templates all need to declare their project namespace to be consistent.

## Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-142

## How does this address that need:

* Bumps the child theme version in style.css to be 0.1.0 (this ideally happens under LM-142 somewhere, and now when we are working with `@since` tags seems as good as any)
* This standardizes all the page templates to use the Mitlib_Child project name, and to use the proper since value of 0.1.0 (the version of the theme in which those files are added). Two templates had the parent theme's project name - they may have been copy/pasted from the parent theme originally and never updated.
* The namespace of Mitlib/Child is declared at the top of all files.

For now I've elected to keep things like the file comment text, and the names of the templates, unchanged. Updating those things will begin in the next PR, as I start to dig into what each template is doing (and what its proper name needs to be, and even whether it needs to exist at all).

## Document any side effects to this change:

* Any template that calls a WordPress class will now have a problem, because those classes exist in the root namespace. The most common example of this is any call to WP_Query, which needs to become \WP_Query in code (same with \Navwalker ).

  Those changes will only become visible as I continue with the work of updating these templates, however - so for this PR I'm only noting this issue.

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No new secrets are created

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
