### PR TITLE
Update namespace where needed

### DIFF
--- a/web/app/themes/mitlib-child/category-maihaugen-gallery.php
+++ b/web/app/themes/mitlib-child/category-maihaugen-gallery.php
@@ -23,7 +23,7 @@ get_header();
 
 		<?php
 
-			$current_query = new WP_Query(
+			$current_query = new \WP_Query(
 				array(
 					'posts_per_page' => -1,
 					'ignore_sticky_posts' => false,
@@ -79,7 +79,7 @@ get_header();
 
 		<?php
 
-		$future_query = new WP_Query(
+		$future_query = new \WP_Query(
 			array(
 				'category_name' => 'maihaugen-gallery',
 				'meta_key'    => 'start_date',  // Load up the event_date meta.
@@ -128,7 +128,7 @@ get_header();
 		 
 		<?php
 
-		$past_query = new WP_Query(
+		$past_query = new \WP_Query(
 			array(
 				'category_name' => 'maihaugen-gallery',
 				'meta_key'    => 'end_date',  // Load up the event_date meta.

--- a/web/app/themes/mitlib-child/category-rotch-library.php
+++ b/web/app/themes/mitlib-child/category-rotch-library.php
@@ -23,7 +23,7 @@ get_header();
 
 		<?php
 
-			$current_query = new WP_Query(
+			$current_query = new \WP_Query(
 				array(
 					'posts_per_page' => -1,
 					'ignore_sticky_posts' => false,
@@ -79,7 +79,7 @@ get_header();
 
 		<?php
 
-		$future_query = new WP_Query(
+		$future_query = new \WP_Query(
 			array(
 				'category_name' => 'rotch-library',
 				'meta_key'    => 'start_date',  // Load up the event_date meta.
@@ -128,7 +128,7 @@ get_header();
 		 
 		<?php
 
-		$past_query = new WP_Query(
+		$past_query = new \WP_Query(
 			array(
 				'category_name' => 'rotch-library',
 				'meta_key'    => 'end_date',  // Load up the event_date meta.

--- a/web/app/themes/mitlib-child/inc/content-feed.php
+++ b/web/app/themes/mitlib-child/inc/content-feed.php
@@ -18,7 +18,7 @@ namespace Mitlib\Child;
 
 	$custom_query_args['paged'] = get_query_var( 'paged' ) ? get_query_var( 'paged' ) : 1;
 
-	$custom_query = new WP_Query( $custom_query_args );
+	$custom_query = new \WP_Query( $custom_query_args );
 
 	$temp_query = $wp_query;
 	$wp_query   = null;

--- a/web/app/themes/mitlib-child/inc/content-front.php
+++ b/web/app/themes/mitlib-child/inc/content-front.php
@@ -31,7 +31,7 @@ if ( count( $sticky ) > 0 ) {
 	);
 
 	// Execute query.
-	$the_query = new WP_Query( $args );
+	$the_query = new \WP_Query( $args );
 
 	if ( $the_query->have_posts() ) {
 

--- a/web/app/themes/mitlib-child/inc/nav-child.php
+++ b/web/app/themes/mitlib-child/inc/nav-child.php
@@ -40,7 +40,7 @@ if ( ! in_array( $siteName, $noChildNav ) && $countPosts > 1 ) {
 					'container_id'      => 'bs-example-navbar-collapse-1',
 					'menu_class'        => 'nav navbar-nav nav-second',
 					'fallback_cb'       => 'navwalker::fallback',
-					'walker'            => new navwalker(),
+					'walker'            => new \navwalker(),
 				)
 			);
 

--- a/web/app/themes/mitlib-child/single.php
+++ b/web/app/themes/mitlib-child/single.php
@@ -65,7 +65,7 @@ get_template_part( 'inc/breadcrumbs', 'child' );
 						'posts_per_page' => 3,
 					);
 				}
-					$related_query = new WP_Query( $args );
+					$related_query = new \WP_Query( $args );
 
 				if ( $related_query->have_posts() ) :
 					?>

--- a/web/app/themes/mitlib-child/templates/page-exhibits-feed.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-feed.php
@@ -23,7 +23,7 @@ get_header( 'child' );
 
 		<?php
 
-			$current_query = new WP_Query(
+			$current_query = new \WP_Query(
 				array(
 					'posts_per_page'      => 10,
 					'ignore_sticky_posts' => false,
@@ -87,7 +87,7 @@ get_header( 'child' );
 
 		<?php
 
-		$future_query = new WP_Query(
+		$future_query = new \WP_Query(
 			array(
 				'post_type'      => 'exhibits',    // Only query exhibits.
 				'meta_key'       => 'start_date',  // Load up the event_date meta.
@@ -136,7 +136,7 @@ get_header( 'child' );
 			 
 			<?php
 
-			$past_query = new WP_Query(
+			$past_query = new \WP_Query(
 				array(
 					'post_type'      => 'exhibits',  // Only query events.
 					'meta_key'       => 'end_date',  // Load up the event_date meta.

--- a/web/app/themes/mitlib-child/templates/page-exhibits-home.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-home.php
@@ -41,7 +41,7 @@ $todaysDate = date( 'm/d/Y H:i:s' );
 					
 					<?php
 
-						$query = new WP_Query(
+						$query = new \WP_Query(
 							array(
 								'post_type' => 'exhibits',
 								'posts_per_page' => 10,

--- a/web/app/themes/mitlib-child/templates/page-exhibits-location.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-location.php
@@ -42,7 +42,7 @@ $location_name = $categories[0]->name;
 
 			<?php
 
-			$current_query = new WP_Query(
+			$current_query = new \WP_Query(
 				array(
 					'post_type'           => 'exhibits',  // Only query exhibits.
 					'category_name'       => $location_name,
@@ -107,7 +107,7 @@ $location_name = $categories[0]->name;
 
 		<?php
 
-		$future_query = new WP_Query(
+		$future_query = new \WP_Query(
 			array(
 				'post_type'      => 'exhibits',  // Only query exhibits.
 				'category_name'  => $location_name,
@@ -155,7 +155,7 @@ $location_name = $categories[0]->name;
 
 		<?php
 
-		$past_query = new WP_Query(
+		$past_query = new \WP_Query(
 			array(
 				'post_type'      => 'exhibits',  // Only query exhibits.
 				'category_name'  => $location_name,

--- a/web/app/themes/mitlib-child/templates/page-exhibits-maihaugen-gallery.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-maihaugen-gallery.php
@@ -23,7 +23,7 @@ get_header( 'child' );
 
 			<?php
 
-			$current_query = new WP_Query(
+			$current_query = new \WP_Query(
 				array(
 					'post_type'           => 'exhibits',  // Only query exhibits.
 					'posts_per_page'      => 10,
@@ -84,7 +84,7 @@ get_header( 'child' );
 
 		<?php
 
-		$future_query = new WP_Query(
+		$future_query = new \WP_Query(
 			array(
 				'post_type'      => 'exhibits',  // Only query exhibits.
 				'meta_key'       => 'start_date',
@@ -138,7 +138,7 @@ get_header( 'child' );
 
 		<?php
 
-		$past_query = new WP_Query(
+		$past_query = new \WP_Query(
 			array(
 				'post_type'      => 'exhibits',  // Only query exhibits.
 				'meta_key'       => 'end_date',

--- a/web/app/themes/mitlib-child/templates/page-exhibits-past.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-past.php
@@ -24,7 +24,7 @@ namespace Mitlib\Child;
 		 
 		<?php
 		$paged = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
-		$past_query = new WP_Query(
+		$past_query = new \WP_Query(
 			array(
 				'post_type'   => 'exhibits',  // Only query events.
 				'meta_key'    => 'end_date',  // Load up the event_date meta.

--- a/web/app/themes/mitlib-child/templates/page-exhibits-rotch-library.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-rotch-library.php
@@ -23,7 +23,7 @@ get_header( 'child' );
 
 			<?php
 
-			$current_query = new WP_Query(
+			$current_query = new \WP_Query(
 				array(
 					'post_type'           => 'exhibits',  // Only query exhibits.
 					'posts_per_page'      => 10,
@@ -83,7 +83,7 @@ get_header( 'child' );
 
 		<?php
 
-		$future_query = new WP_Query(
+		$future_query = new \WP_Query(
 			array(
 				'post_type'      => 'exhibits',  // Only query exhibits.
 				'meta_key'       => 'start_date',
@@ -136,7 +136,7 @@ get_header( 'child' );
 
 		<?php
 
-		$past_query = new WP_Query(
+		$past_query = new \WP_Query(
 			array(
 				'post_type'      => 'exhibits',  // Only query exhibits.
 				'meta_key'       => 'end_date',


### PR DESCRIPTION
This updates any call to `WP_Query` and `Navwalker` class to use the root namespace.

To confirm, you should be able to search the child theme for those strings, and see only references to `\WP_Query` or `\Navwalker`.

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are changed

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
