### PR TITLE
Update child theme to use parent's breadcrumb function

### DIFF
--- a/web/app/themes/mitlib-child/inc/breadcrumbs-child.php
+++ b/web/app/themes/mitlib-child/inc/breadcrumbs-child.php
@@ -12,5 +12,5 @@ namespace Mitlib\Child;
 <div class="betterBreadcrumbs hidden-phone" role="navigation" aria-label="breadcrumbs">
 	<span><a href="/">Libraries home</a></span>
 	<span><a href="<?php echo esc_url( home_url() ); ?>"><?php bloginfo(); ?></a></span>
-	<?php betterChildBreadcrumbs(); ?>
+	<?php \Mitlib\Parent\better_breadcrumbs(); ?>
 </div>

--- a/web/app/themes/mitlib-parent/functions.php
+++ b/web/app/themes/mitlib-parent/functions.php
@@ -406,7 +406,7 @@ function better_breadcrumbs() {
 			),
 		);
 		if ( '' != $parent_breadcrumb && 1 != $hide_parent ) {
-			echo '<span>' . wp_kses( $parent_breadcrumb, $allowed ) . '</span>';
+			echo '<span>' . wp_kses( $parent_breadcrumb, $allowed_html ) . '</span>';
 		}
 		if ( '' != $child_breadcrumb ) {
 			echo '<span>' . esc_html( $page_title ) . '</span>';


### PR DESCRIPTION
The legacy child theme had its own implementation of a breadcrumb function, which was nearly identical to the one in the parent theme.

* Parent theme function: https://github.com/MITLibraries/MITlibraries-parent/blob/main/functions.php#L874-L902
* Child theme function: https://github.com/MITLibraries/MITLibraries-child/blob/master/functions.php#L47-L75

(The only difference I see is, in the parent theme, there is a `$hideParent` value being looked up in a custom field. That custom field doesn't seem to exist anymore, and the "shorter breadcrumb" function relies on WordPress categories, like https://github.com/MITLibraries/MITlibraries-parent/blob/main/page.php#L27-L31 ). That get_field call fails silently if the field is not defined, so there's no harm in leaving it in for now. Once we get through bringing in content, we can remove it if the field doesn't surface.

This PR updates the reference to the legacy breadcrumb function, calling instead the parent theme's better_breadcrumb function from that partial. Please note, however, that there are still breadcrumb partials in this theme. The other two partials are not affected by this change.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-142

### Document any side effects to this change:

This also fixes a bug in the parent theme breadcrumb function, where the wrong variable name is being passed to wp_kses to define allowed markup.

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No new secrets are defined

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
