### PR TITLE
Implement content_nav function in parent and child themes

### DIFF
--- a/web/app/themes/mitlib-child/archive.php
+++ b/web/app/themes/mitlib-child/archive.php
@@ -58,7 +58,7 @@ get_header( 'child' ); ?>
 
 			endwhile;
 
-			twentytwelve_content_nav( 'nav-below' );
+			\Mitlib\Parent\content_nav( 'nav-below' );
 			?>
 
 		<?php else : ?>

--- a/web/app/themes/mitlib-child/index.php
+++ b/web/app/themes/mitlib-child/index.php
@@ -29,7 +29,7 @@ get_header( 'child' ); ?>
 			
 				<?php endwhile; // End of the loop. ?>
 
-				<?php twentytwelve_content_nav( 'nav-below' ); ?>
+				<?php \Mitlib\Parent\content_nav( 'nav-below' ); ?>
 			</div>
 				
 				<?php get_sidebar(); ?>				

--- a/web/app/themes/mitlib-child/search.php
+++ b/web/app/themes/mitlib-child/search.php
@@ -35,7 +35,7 @@ get_header( 'child' ); ?>
 
 					<?php endwhile; ?>
 
-				<?php twentytwelve_content_nav( 'nav-below' ); ?>
+				<?php \Mitlib\Parent\content_nav( 'nav-below' ); ?>
 
 			<?php else : ?>
 

--- a/web/app/themes/mitlib-parent/archive.php
+++ b/web/app/themes/mitlib-parent/archive.php
@@ -54,7 +54,7 @@ get_header(); ?>
 
 			endwhile;
 
-			twentytwelve_content_nav( 'nav-below' );
+			content_nav( 'nav-below' );
 			?>
 
 		<?php else : ?>

--- a/web/app/themes/mitlib-parent/functions.php
+++ b/web/app/themes/mitlib-parent/functions.php
@@ -429,6 +429,26 @@ function cf( $name ) {
 }
 
 /**
+ * The content_nav function displays navigation to next/previous pages when
+ * applicable.
+ *
+ * @param string $html_id The value to use for the ID attribute of the nav
+ *                        element.
+ */
+function content_nav( $html_id ) {
+	global $wp_query;
+
+	if ( $wp_query->max_num_pages > 1 ) : ?>
+		<nav id="<?php echo esc_attr( $html_id ); ?>" class="navigation" role="navigation">
+			<h3 class="assistive-text">Post navigation</h3>
+			<div class="nav-previous alignleft"><?php next_posts_link( __( '<span class="meta-nav">&larr;</span> Older posts', 'twentytwelve' ) ); ?></div>
+			<div class="nav-next alignright"><?php previous_posts_link( __( 'Newer posts <span class="meta-nav">&rarr;</span>', 'twentytwelve' ) ); ?></div>
+		</nav><!-- #<?php echo esc_attr( $html_id ); ?> .navigation -->
+		<?php
+	endif;
+}
+
+/**
  * The get_root function finds the post at the root of a content tree below a
  * specified leaf post.
  *

--- a/web/app/themes/mitlib-parent/tag.php
+++ b/web/app/themes/mitlib-parent/tag.php
@@ -42,7 +42,7 @@ get_header(); ?>
 
 			endwhile;
 
-			twentytwelve_content_nav( 'nav-below' );
+			content_nav( 'nav-below' );
 			?>
 
 		<?php else : ?>


### PR DESCRIPTION
### Why are these changes being introduced:

* There was a twentytwelve_content_nav function in the legacy parent theme, which was called in some minor templates there but more significantly in the child theme. That function needs to be put in place, or the templates updated to remove references to it.
* Original function: https://github.com/MITLibraries/MITlibraries-parent/blob/main/functions.php#L374-L387

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-142

### How does this address that need:

* This places and updates the function, renaming it to content_nav since we are expunging references to the twentytwelve name (the parent theme used to descend from twentytwelve).
* References to content_nav from the parent theme (in two minor files) are updated to the correct name.
* References to the function from the child theme (in index.php and two other files) are updated to use the correct namespace.

### Document any side effects to this change:

* None

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No new secrets are created

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
