### PR TITLE
Update domain names now that contract is signed

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -83,8 +83,8 @@ down the Dev -> Test -> Live pipeline.
 
   ```bash
   terminus remote:wp mitlib-wp-network.engx-201 -- search-replace \
-    dev-mitlib-wp-network.sites.presalesexamples.com engx-201-mitlib-wp-network.sites.presalesexamples.com \
-    --url=dev-mitlib-wp-network.sites.presalesexamples.com \
+    dev-mitlib-wp-network.pantheonsite.io engx-201-mitlib-wp-network.pantheonsite.io \
+    --url=dev-mitlib-wp-network.pantheonsite.io \
     --network
   ```
 
@@ -189,7 +189,7 @@ Maintaining these symlinks involves two steps. For a hypothetical site like `lib
 
 * `lando start` will get your local containers running.
 * `lando pull` will prompt for the environment on Pantheon from which to grab the database and files. (Our default workflow is to not prompt for copying code directly from Pantheon)
-* `lando wp search-replace dev-mitlib-wp-network.sites.presalesexamples.com mitlib-wp-network.lndo.site --url=dev-mitlib-wp-network.sites.presalesexamples.com --network` will cleanup the database to work with our local site name. Note: `dev-mitlib...` would change to match whichever multidev you pulled data from in the previous step. This assumes `dev` but if you chose `engxhallo`, the prefix would change to `engxhallo-mitlib`. If the command finishes saying it made 0 replacements, it's likely you ran a command for replacing that didn't match the multidev you pulled from.
+* `lando wp search-replace dev-mitlib-wp-network.pantheonsite.io mitlib-wp-network.lndo.site --url=dev-mitlib-wp-network.pantheonsite.io --network` will cleanup the database to work with our local site name. Note: `dev-mitlib...` would change to match whichever multidev you pulled data from in the previous step. This assumes `dev` but if you chose `engxhallo`, the prefix would change to `engxhallo-mitlib`. If the command finishes saying it made 0 replacements, it's likely you ran a command for replacing that didn't match the multidev you pulled from.
 * Access the site at: `https://mitlib-wp-network.lndo.site`
 
 You can completely start your local environment over with `lando destroy` - after which you should follow each step in the above process.

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -21,7 +21,7 @@ define( 'WP_ALLOW_MULTISITE', true );
 define( 'MULTISITE', true );
 define( 'SUBDOMAIN_INSTALL', false );
 $base = '/';
-# define( 'DOMAIN_CURRENT_SITE', 'dev-mitlib-wp-network.sites.presalesexamples.com' );
+# define( 'DOMAIN_CURRENT_SITE', 'dev-mitlib-wp-network.pantheonsite.io' );
 define( 'PATH_CURRENT_SITE', '/' );
 define( 'SITE_ID_CURRENT_SITE', 1 );
 define( 'BLOG_ID_CURRENT_SITE', 1 );
@@ -38,17 +38,17 @@ if ( ! empty( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
       // define( 'DOMAIN_CURRENT_SITE', 'example-network.com' );
       break;
     case 'test':
-      define( 'DOMAIN_CURRENT_SITE', 'test-mitlib-wp-network.sites.presalesexamples.com' );
+      define( 'DOMAIN_CURRENT_SITE', 'test-mitlib-wp-network.pantheonsite.io' );
       break;
     case 'dev':
-      define( 'DOMAIN_CURRENT_SITE', 'dev-mitlib-wp-network.sites.presalesexamples.com' );
+      define( 'DOMAIN_CURRENT_SITE', 'dev-mitlib-wp-network.pantheonsite.io' );
       break;
     case 'lando':
       define( 'DOMAIN_CURRENT_SITE', 'mitlib-wp-network.lndo.site' );
       break;
     default:
       # Catch-all to accommodate default naming for multi-dev environments.
-      define( 'DOMAIN_CURRENT_SITE', $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $_ENV['PANTHEON_SITE_NAME'] . '.sites.presalesexamples.com' );
+      define( 'DOMAIN_CURRENT_SITE', $_ENV['PANTHEON_ENVIRONMENT'] . '-' . $_ENV['PANTHEON_SITE_NAME'] . '.pantheonsite.io' );
       break;
   }
 


### PR DESCRIPTION
We have hard-coded references in code to the preview domain which we were given during contract negotiations. Now that we have a signed contract, new multidev environments need to be created using the pantheonsite.io domain (at least until we get our own domain in place)

### How does this address that need:

This updates references to sites.presalesexamples.com to be pantheonsite.io instead. This should allow new multidev environments to be created successfully, and also change our Dev/Test/Live tiers over to their correct domain names.

You can confirm that this change is effective by visiting the review app at the new domain: https://contract-mitlib-wp-network.pantheonsite.io/

### Document any side effects to this change:

We will need to run search-replace on the Dev/Test/Live environments as this change is propogated up the pipeline.

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No new secrets are defined

### Documentation

- [x] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
