### PR TITLE
Remove isRoot / pageRoot calculations

### DIFF
--- a/web/app/themes/mitlib-child/header-slim.php
+++ b/web/app/themes/mitlib-child/header-slim.php
@@ -56,10 +56,3 @@ namespace Mitlib\Child;
 			</a><!-- End /barton-account -->
 
 		</header>
-
-		<?php
-
-			$pageRoot = getRoot( $post );
-			$section = get_post( $pageRoot );
-
-		?>

--- a/web/app/themes/mitlib-child/inc/content-front.php
+++ b/web/app/themes/mitlib-child/inc/content-front.php
@@ -8,10 +8,7 @@
 
 namespace Mitlib\Child;
 
-global $isRoot;
 ?>
-
-
 <div class="main-content content-main">
 	
 	<div class="entry-content">

--- a/web/app/themes/mitlib-child/inc/content-widgetized.php
+++ b/web/app/themes/mitlib-child/inc/content-widgetized.php
@@ -8,17 +8,7 @@
 
 namespace Mitlib\Child;
 
-global $isRoot;
 ?>
-
-<?php
-
-	$pageRoot = getRoot( $post );
-	$section = get_post( $pageRoot );
-
-?>
-
-
 <div class="main-content">
 	
 	<div class="entry-content">

--- a/web/app/themes/mitlib-child/inc/exhibits-current.php
+++ b/web/app/themes/mitlib-child/inc/exhibits-current.php
@@ -10,8 +10,6 @@
 
 namespace Mitlib\Child;
 
-global $isRoot;
-
 ?>
 
 <?php

--- a/web/app/themes/mitlib-child/inc/exhibits-past.php
+++ b/web/app/themes/mitlib-child/inc/exhibits-past.php
@@ -9,8 +9,6 @@
 
 namespace Mitlib\Child;
 
-global $isRoot;
-
 ?>
 
 <?php

--- a/web/app/themes/mitlib-child/inc/exhibits-upcoming.php
+++ b/web/app/themes/mitlib-child/inc/exhibits-upcoming.php
@@ -9,8 +9,6 @@
 
 namespace Mitlib\Child;
 
-global $isRoot;
-
 ?>
 
 <?php

--- a/web/app/themes/mitlib-child/templates/page-posts-feed.php
+++ b/web/app/themes/mitlib-child/templates/page-posts-feed.php
@@ -13,11 +13,6 @@
 
 namespace Mitlib\Child;
 
-$pageRoot = getRoot( $post );
-$section = get_post( $pageRoot );
-$isRoot = $section->ID === $post->ID;
-
-
 get_header( 'child' );
 
 get_template_part( 'inc/breadcrumbs', 'child' ); ?>

--- a/web/app/themes/mitlib-child/templates/page-widgetized.php
+++ b/web/app/themes/mitlib-child/templates/page-widgetized.php
@@ -13,11 +13,6 @@
 
 namespace Mitlib\Child;
 
-$pageRoot = getRoot( $post );
-$section = get_post( $pageRoot );
-$isRoot = $section->ID == $post->ID;
-
-
 get_header( 'child' );
 
 get_template_part( 'inc/breadcrumbs', 'child' ); ?>


### PR DESCRIPTION
### Why are these changes being introduced:
There are a number of references to $pageRoot, $isRoot, or the getRoot function which are apparently not needed in the child theme.

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/lm-142

### How does this address that need:

This removes all references to the getRoot function, as well as to the $isRoot or $pageRoot variables. While the parent them makes very limited use of these values, we have moved away from pre-calculating them in many templates, and only deal with these variables when they are needed in a specific template.

### Document any side effects to this change:

There don't appear to be any in local testing - although if I've missed some references, they will continue to cause page crashes that will show up in Sentry or other logs.

## Developer

### Secrets

- [x] No new secrets are created

### Documentation

- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
