### PR TITLE
Add settings to Child theme Customizer

### DIFF
--- a/web/app/themes/mitlib-child/functions.php
+++ b/web/app/themes/mitlib-child/functions.php
@@ -74,6 +74,62 @@ function sidebars_init() {
 add_action( 'widgets_init', 'Mitlib\Child\sidebars_init' );
 
 /**
+ * Sets up theme defaults and registers the various WordPress features that it
+ * supports. This was function was borrowed from Twenty Twelve.
+ *
+ * @link https://developer.wordpress.org/themes/functionality/custom-headers/
+ * @uses add_theme_support() To enable the theme's support for custom header
+ *                           images.
+ */
+function theme_setup() {
+	$args = array(
+		'width' => 1250,
+		'height' => 800,
+		'uploads' => true,
+	);
+	add_theme_support( 'custom-header', $args );
+}
+add_action( 'after_setup_theme', 'Mitlib\Child\theme_setup' );
+
+/**
+ * Define a new Menu Style section within the Customizer.
+ *
+ * @link https://developer.wordpress.org/themes/customize-api/customizer-objects/
+ * @param type $wp_customize The Customizer object which we are extending.
+ */
+function theme_menu_style_customizer( $wp_customize ) {
+
+	$wp_customize->add_section(
+		'menu_style_section',
+		array(
+			'title' => 'Menu Style',
+		)
+	);
+
+	$wp_customize->add_setting(
+		'menu_style_setting',
+		array(
+			'default' => 'Full Menu',
+			'type' => 'option',
+		)
+	);
+
+	$wp_customize->add_control(
+		'menu_style_setting',
+		array(
+			'label'   => 'Menu Style',
+			'section' => 'menu_style_section',
+			'type'    => 'radio',
+			'choices'    => array(
+				'full' => 'Full Menu',
+				'slim' => 'Slim No Menu',
+			),
+		)
+	);
+}
+add_action( 'customize_register', 'Mitlib\Child\theme_menu_style_customizer' );
+
+/**
  * Define register_child_nav function.
  */
 function register_child_nav() {


### PR DESCRIPTION
When we started importing real content to some sites that use the Child theme, the team realized that some needed functionality had not yet been implemented:

1. Support for custom header images (built into WordPress, but needs to be enabled by themes)
2. A custom theme setting to allow sites to choose which navigation menu they use (the full meganav, or a slim option)

Examples of these two menus:
* Full navigation: https://libraries.mit.edu/data-management/
* Slim navigation: https://libraries.mit.edu/creos/
 
## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No new secrets are defined

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
