### PR TITLE
Adds documentation about touchstone review app

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -16,6 +16,16 @@ To contribute to this application, please make sure your local environment inclu
 * [Composer](https://getcomposer.org) for managing third-party plugins and themes within WordPress, and tooling outside of WordPress.
 * [Lando](https://lando.dev/) for running a local copy of this application.
 
+### WebOps workflow
+
+Beyond the production instance of the Libraries' website, we maintain a number of separate instances for various purposes. These are described in general terms here; for a current list of instances, and links to each, please consult the Pantheon dashboard or Terminus CLI.
+
+In general, this application is developed and managed using Pantheon's [WebOps Workflow](https://pantheon.io/docs/pantheon-workflow), which involves a progression between three tiers in a pipeline: Dev, Test, and Live.
+
+Beyond these three tiers, we can create additional instances using either the Terminus CLI or Pantheon's web-based dashboard. While many of these instances will be short-lived in order to develop specific features, there is one long-running `touchstone` instance for management of our Touchstone integration.
+
+Instructions for how to create, manage, and remote these instances can be found below.
+
 ### Branch names
 
 Pantheon imposes [restrictions on branch names](https://pantheon.io/docs/guides/multidev/create-multidev), including a length limit and some reserved words. **The easiest convention is to name your branch after its Jira ticket, which sets up the following relationships:**


### PR DESCRIPTION
## Why are these changes being introduced:

* We need to document why the touchstone review app exists somewhere, to prevent future-us from deleting it without due consideration.

## Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-195

## How does this address that need:

* This adds a section to our readme to descibe how we use the WebOps workflow, including that there are three permanant copies of the site (Dev, Test, and Live). Beyond those, we also describe briefly that more copies are possible, including the quasi-permanent Touchstone copy.
* I'm leery of handing out links to non-production sites, so I've opted not to link to any of these instances - there's a line in the text that directs people to either th Pantheon dashboard or the Terminus command line tool for current links.

## Document any side effects to this change:

* The readme is getting increasingly unwieldy and long.

## Developer

### Secrets

- [x] No new secrets are created

### Documentation

- [x] Project documentation has been updated

### Accessibility

- [x] No accessibility changes are made in this work

### Stakeholder approval

- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
