### PR TITLE
Configure dev and test for mit domains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,7 @@ Thumbs.db
 # SASS #
 ##########
 .sass-cache
+
+# MISC #
+##########
+.vscode

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -38,10 +38,10 @@ if ( ! empty( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
       // define( 'DOMAIN_CURRENT_SITE', 'example-network.com' );
       break;
     case 'test':
-      define( 'DOMAIN_CURRENT_SITE', 'test-mitlib-wp-network.pantheonsite.io' );
+      define( 'DOMAIN_CURRENT_SITE', 'www-test.libraries.mit.edu' );
       break;
     case 'dev':
-      define( 'DOMAIN_CURRENT_SITE', 'dev-mitlib-wp-network.pantheonsite.io' );
+      define( 'DOMAIN_CURRENT_SITE', 'www-dev.libraries.mit.edu' );
       break;
     case 'lando':
       define( 'DOMAIN_CURRENT_SITE', 'mitlib-wp-network.lndo.site' );


### PR DESCRIPTION
Why are these changes being introduced:

* we prefer the *.libraries.mit.edu domains for our dev/test tiers

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/LM-234

How does this address that need:

* changes the hard coded values from pantheon to mit for dev and test

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
