### PR TITLE
Adds role-specific styles for content debugging

### DIFF
--- a/web/app/themes/mitlib-parent/css/super-admin.css
+++ b/web/app/themes/mitlib-parent/css/super-admin.css
@@ -1,0 +1,21 @@
+/* Links to the production URL are in green. */
+body.admin-bar a[href^="https://libraries."],
+body.admin-bar a[href^="http://libraries."] {
+  border: 5px solid green;
+}
+
+body.admin-bar img[src^="https://libraries."],
+body.admin-bar img[src^="http://libraries."] {
+	border: 5px solid green;
+}
+
+/* Links to non-productions URLs are thicker and red, to be annoying and force changes. */
+body.admin-bar a[href^="https://libraries-"],
+body.admin-bar a[href^="http://libraries-"] {
+  border: 10px solid red;
+}
+
+body.admin-bar img[src^="https://libraries-"],
+body.admin-bar img[src^="http://libraries-"] {
+	border: 10px solid red;
+}

--- a/web/app/themes/mitlib-parent/functions.php
+++ b/web/app/themes/mitlib-parent/functions.php
@@ -127,6 +127,8 @@ function setup_scripts_styles() {
 
 	wp_register_style( 'bootstrapCSS', get_stylesheet_directory_uri() . '/css/bootstrap.css', array(), $theme_version, false );
 
+	wp_register_style( 'super-admin', get_template_directory_uri() . '/css/super-admin.css', array(), $theme_version, false );
+
 	/**
 	 * Register javascript.
 	 */
@@ -211,6 +213,10 @@ function setup_scripts_styles() {
 	/**
 	 * Conditionally enqueue assets.
 	 */
+	if ( is_super_admin() ) {
+		wp_enqueue_style( 'super-admin' );
+	}
+
 	if ( is_page_template( 'page-authenticate.php' ) || is_page_template( 'page-forms.php' ) || is_page_template( 'templates/page.php' ) ) {
 		wp_enqueue_style( 'parent-forms' );
 		wp_enqueue_script( 'formsJS' );


### PR DESCRIPTION
There are lingering pieces of content across the WordPress network with hard-coded domain names, either to our legacy production site or to our staging site. While links to production are just something to be careful about (and not click on during content review), links to non-production URLs should be made garish for site admins to help us target and fix them.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-211

### Parallel change to legacy parent theme:

* https://github.com/MITLibraries/MITlibraries-parent/pull/362

### How does this address that need:

* This creates a new stylesheet in the parent theme which adds a noticeable border to any content that is loaded from (or links to) legacy domain names.
* The stylesheet is registered in a way that allows it to be loaded from the parent or child themes.
* The stylesheet is only enqueued for users in the Super Admin role, which would allow it to be in place on an ongoing basis, beyond this migration.

### Document any side effects to this change:

* There is one additional asset being managed by the theme, although these limits are less relevant now.
* This feature can probably be reverted after migration, but that can be a ticket for future-us.

## Developer

### Secrets

- [x] No secrets are affected by this work

### Documentation

- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
