### PR TITLE
Updates Child theme to include get_exhibit_locations function, and fixing namespaces

### DIFF
--- a/web/app/themes/mitlib-child/functions.php
+++ b/web/app/themes/mitlib-child/functions.php
@@ -196,6 +196,65 @@ function custom_excerpt( $new_length = 20, $new_more = '...' ) {
 }
 
 /**
+ * Function to look up exhibit location information
+ *
+ * Multiple templates in this theme need to display information about the
+ * location of an Exhibit record. This can be a bit more complex than might be
+ * expected, so we have this helper function to assist.
+ *
+ * Exhibit locations are recorded using Categories, but they can also be placed
+ * in a "Featured" category (which is not a location, and must be ignored).
+ *
+ * Additionally, there is a catchall category of "Uncategorized", for exhibits
+ * in non-standard locations. For these Exhibits, the name to be displayed is
+ * found in a custom "uncategorized_location" field.
+ *
+ * This function:
+ * 1. Looks up all categories for the current Exhibit post ID.
+ * 2. Rebuilds this list without a "Featured" item, if found. In the process it
+ *    extracts only the name and slug for these categories, removing the WP_Term
+ *    in favor of a simple Array.
+ * 3. Calculates the displayed name for the location, along with a link and
+ *    initial which the theme templates expect.
+ * 4. Returns these three values (name, link, and initial) in an array.
+ */
+function get_exhibit_location() {
+	// 1. Look up all categories for the current post ID.
+	$locations_array = get_the_category();
+
+	// 2. Rebuilt the array without a "Featured" category entry, if found.
+	$locations_rebuild = array();
+	foreach ( $locations_array as $term ) {
+		if ( 'Featured' === $term->name ) {
+			continue;
+		}
+		array_push(
+			$locations_rebuild,
+			array(
+				'name' => $term->name,
+				'slug' => $term->slug,
+			)
+		);
+	}
+
+	// 3. Calculate the name, link, and initial from the rebuilt array.
+	$location_name = 'Multiple Locations';
+	if ( 1 === count( $locations_rebuild ) ) {
+		$location_name = $locations_rebuild[0]['name'];
+		if ( 'Uncategorized' === $location_name ) {
+			$location_name = get_field( 'uncategorized_location' );
+		}
+	}
+	$location_initial = substr( $location_name, 0, 1 );
+
+	// 4. Return those calculated values in an array.
+	return array(
+		'name'    => $location_name,
+		'initial' => $location_initial,
+	);
+}
+
+/**
  * Get URL of first image in a post
  */
 function get_first_post_image() {

--- a/web/app/themes/mitlib-child/inc/exhibits-detail.php
+++ b/web/app/themes/mitlib-child/inc/exhibits-detail.php
@@ -34,9 +34,9 @@ $location_info = get_exhibit_location();
 			</div>
 			<div class="exhibit-ends">
 				<?php
-				$today = new DateTime( gmdate( 'Y-m-d' ) );
-				$start = new DateTime( get_field( 'start_date' ) );
-				$end = new DateTime( get_field( 'end_date' ) );
+				$today = new \DateTime( gmdate( 'Y-m-d' ) );
+				$start = new \DateTime( get_field( 'start_date' ) );
+				$end = new \DateTime( get_field( 'end_date' ) );
 				if ( $end < $today ) {
 					?>
 					Ended <?php the_field( 'end_date' ); ?>


### PR DESCRIPTION
This PR attempts to address two issues that were identified during stakeholder testing of the Exhibits site:

- A function from the legacy theme was accidentally not brought over to the new theme
- A few calls to native PHP classes were not properly namespaced

Both of these issues were crashing page loads; the existence of the second problem was masked by the first.

## Developer

### Ticket

https://mitlibraries.atlassian.net/browse/LM-247

### Secrets

- [x] No new secrets are defined

### Documentation

- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
