### PR TITLE
Removes three plugins which are complicating things

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,18 +79,6 @@
     },
     {
       "type": "vcs",
-      "url": "https://github.com/mitlibraries/lightbox-plus"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/mitlibraries/slideshow-gallery"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/mitlibraries/types"
-    },
-    {
-      "type": "vcs",
       "url": "https://github.com/mitlibraries/wp-slug-trimmer"
     },
     {
@@ -107,9 +95,6 @@
     "mitlibraries/acf-location-field": "^1.0",
     "mitlibraries/cpt-onomies": "^1.4",
     "mitlibraries/dynamic-menu-manager": "^1.0",
-    "mitlibraries/lightbox-plus": "^2.7",
-    "mitlibraries/slideshow-gallery": "dev-main",
-    "mitlibraries/types": "^2.3",
     "mitlibraries/wp-slug-trimmer": "^1.1",
     "nsp-code/advanced-post-types-order": "^4.4",
     "oscarotero/env": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a0d460b332c8730c5636da32ba20e29",
+    "content-hash": "2a3589c79140ce1a8e5d3b031b093d94",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ead665bab0ac3ab9dc56e0cba2eddc10",
+    "content-hash": "2a0d460b332c8730c5636da32ba20e29",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -926,97 +926,6 @@
                 "issues": "https://github.com/MITLibraries/dynamic-menu-manager/issues"
             },
             "time": "2022-12-06T20:59:34+00:00"
-        },
-        {
-            "name": "mitlibraries/lightbox-plus",
-            "version": "2.7.2",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:MITLibraries/lightbox-plus.git",
-                "reference": "cc1d91a5e3fd3dc9e79dbdec49352f03ca286b63"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/MITLibraries/lightbox-plus/zipball/cc1d91a5e3fd3dc9e79dbdec49352f03ca286b63",
-                "reference": "cc1d91a5e3fd3dc9e79dbdec49352f03ca286b63",
-                "shasum": ""
-            },
-            "type": "wordpress-plugin",
-            "license": [
-                "GPL-2.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "Dan Zappone"
-                }
-            ],
-            "description": "Lightbox Plus Colorbox permits users to view larger versions of images, simple slideshows, videos, and content all in an overlay",
-            "support": {
-                "source": "https://github.com/MITLibraries/lightbox-plus/tree/2.7.2",
-                "issues": "https://github.com/MITLibraries/lightbox-plus/issues"
-            },
-            "time": "2022-12-06T21:29:44+00:00"
-        },
-        {
-            "name": "mitlibraries/slideshow-gallery",
-            "version": "dev-main",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:MITLibraries/slideshow-gallery.git",
-                "reference": "8daf9198a68d22843d42950a1329dc3a458367c3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/MITLibraries/slideshow-gallery/zipball/8daf9198a68d22843d42950a1329dc3a458367c3",
-                "reference": "8daf9198a68d22843d42950a1329dc3a458367c3",
-                "shasum": ""
-            },
-            "default-branch": true,
-            "type": "wordpress-plugin",
-            "license": [
-                "GPL-2.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "Tribulant"
-                }
-            ],
-            "description": "Feature content in a JavaScript powered slideshow gallery showcase on your WordPress website",
-            "support": {
-                "source": "https://github.com/MITLibraries/slideshow-gallery/tree/1.6.12.1-mitlib3",
-                "issues": "https://github.com/MITLibraries/slideshow-gallery/issues"
-            },
-            "time": "2022-12-06T21:58:02+00:00"
-        },
-        {
-            "name": "mitlibraries/types",
-            "version": "2.3.5",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:MITLibraries/types.git",
-                "reference": "c0c5fb8923aaac043d0ba0da39cfe0f0e7eea198"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/MITLibraries/types/zipball/c0c5fb8923aaac043d0ba0da39cfe0f0e7eea198",
-                "reference": "c0c5fb8923aaac043d0ba0da39cfe0f0e7eea198",
-                "shasum": ""
-            },
-            "type": "wordpress-plugin",
-            "license": [
-                "GPL-2.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "OnTheGoSystems"
-                }
-            ],
-            "description": "Toolset Types defines custom content in WordPress",
-            "support": {
-                "source": "https://github.com/MITLibraries/types/tree/2.3.5",
-                "issues": "https://github.com/MITLibraries/types/issues"
-            },
-            "time": "2022-12-06T21:42:13+00:00"
         },
         {
             "name": "mitlibraries/wp-slug-trimmer",
@@ -4246,7 +4155,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "connectthink/wp-scss": 10,
-        "mitlibraries/slideshow-gallery": 20,
         "pantheon-upstreams/upstream-configuration": 20,
         "roave/security-advisories": 20
     },

--- a/docs/howto/test-plugins.md
+++ b/docs/howto/test-plugins.md
@@ -137,13 +137,6 @@ template file.
 
 Confirm that the sitemap is visible at `/sitemap.xml` on any site.
 
-## Lightbox Plus Colorbox
-
-There should be a "Lightbox Plus Colorbox" entry under the Appearance are in the
-admin dashboard. One of the tabs on this screen is a Demo/Test image.
-
-_I don't know where to look in our content for any use of this plugin._
-
 ## Media Libary Assistant
 
 Under the "Media" area of the admin dashboard, you should see links for "Att. 
@@ -268,15 +261,6 @@ You should see an option to make the record sticky.
 
 _This plugin is only used on the News site._
 
-## Slideshow Gallery
-
-**Removal candidate**
-
-1. On the Collections site, you should see a "Slideshow" item on the sidebar.
-2. When editing the "Charles J. Connick Stained Glass Foundation Collection"
-page, you should see this shortcode: `[tribulant_slideshow gallery_id="1"]`.
-3. When viewing the same page, you should see a slideshow of images.
-
 ## Slug Trimmer
 
 _This plugin is only used on the News site._
@@ -289,10 +273,6 @@ item on the sidebar.
 near the bottom of the page, you should see a "Reload via MIT Libs" link.
 
 ## TablePress
-
-_This plugin is only used on the Music Oral History site._
-
-## Toolset Types
 
 _This plugin is only used on the Music Oral History site._
 


### PR DESCRIPTION
This removes three plugins which are interfering with the site's operations now that we're on PHP 8.0:
* Lightbox Plus
* Slideshow Gallery
* Types

Each of these are interfering with various page loads on the site. The functionality they provide is something we are willing to live without, subject to the following notes:

1. Lightbox Plus enables certain content to load in a lightbox / modal display, which we are willing to accept. The plugin is used by less than half a dozen sites on the network.
2. Slideshow Gallery is only used by the Collections Spotlights site, which we are reasonably confident will be retired during the migration. Even if the site is chosen to continue, the galleries themselves will need to be re-constructed as there is no easy export/import workflow for content managed by the plugin.
3. Types is only used on Music Oral History, which we are hopeful of retiring. Similar to the Collections Spotlights site, if the site does end up getting retained, the content will need to be rebuilt.

## Developer

### Secrets

- [x] No new secrets are created

### Documentation

- [x] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
