### PR TITLE
Suppress default gallery styling in child theme

### DIFF
--- a/web/app/themes/mitlib-child/functions.php
+++ b/web/app/themes/mitlib-child/functions.php
@@ -161,6 +161,15 @@ function prune_inherited_templates( $page_templates ) {
 add_filter( 'theme_page_templates', 'Mitlib\Child\prune_inherited_templates' );
 
 /**
+ * Remove native gallery styling.
+ *
+ * By default, WordPress includes some inline CSS rules when using a gallery
+ * shorttag. This filter removes that, as we have our own rules in the child
+ * theme for these styles.
+ */
+add_filter( 'use_default_gallery_style', '__return_false' );
+
+/**
  * ============================================================================
  * ============================================================================
  * These functions are defined here, without adding them via add_action. They


### PR DESCRIPTION
### Why are these changes being introduced:

* The Child theme includes its own styling rules for galleries of media, which conflict with the rules that WordPress includes by default.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-246

### How does this address that need:

* This adds the filter statement from the legacy child theme which suppresses the default inlines styles - allowing only our own styles to be used by browsers to render galleries.

### Document any side effects to this change:

* We're doing a little more work ourselves, rather than letting WordPress' defaults to the work for us.

## Developer

### Secrets

- [x] No secrets are changed

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
