### PR TITLE
Update checked versions of PHP during CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0', '8.1']
+        php-version: ['8.0', '8.1', '8.2']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
** Why are these changes being introduced:

* We recently moved the application from PHP 7.4 to PHP 8.0 on Pantheon, and PHP 8.2 has been officially released since we started the project.
* Because of this change, some dependencies have been updated to versions that no longer work on PHP 7.4, which results in some CI failures which are not relevant.

** Relevant ticket(s):

n/a

** How does this address that need:

* This updates the list of PHP versions that we check the codebase against, now that we've upgraded away from PHP 7.4.
* Now that PHP 8.2 has been officially released, we add that to the list of checked PHP versions.

** Document any side effects to this change:

* None

## Developer

### Secrets

- [x] No new secrets are introduced

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
