### PR TITLE
Adds web/wp-content to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@ web/app/uploads/*
 !web/app/uploads/.gitkeep
 web/app/cache/*
 
+# Ordinarily this path would not exist - and it does not when I inspect any
+# multidev on Pantheon. However, after pulling content locally using "lando
+# pull", this path gets populated with a lot of uploaded files. So we are
+# ignoring it here to prevent accidentally committing over 1,000 images.
+# Again.
+web/wp-content
+
 # WordPress is installed in web/wp so that it can be fully managed by Composer.
 # This ensures that the WordPress directory is clean and doesn't contain any
 # files other than those that come with the WordPress package.


### PR DESCRIPTION
This adds the `web/wp-content` path to the project .gitignore file, because Lando appears to be placing uploaded files here when you pull content down for local development.

This can be confirmed by setting the Oops multidev to SFTP mode, and inspecting the contents of the container - comparing to what exists locally.

- Within Lando, there are over 1,000 images in `web/wp-content`.
- Within Pantheon's Oops multidev (and the others I've inspected), that path does not exist at all.

Based on this, and a few instances already where I've accidentally committed a large number of files after carelessly typing `git add .`, I'm proposing this change to just ignore the directory. So long as we don't actually need that path for anything legitimate, this feels like a safe thing to do.

## Developer

### Secrets

- [x] No secrets are affected

### Documentation

- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
