### PR TITLE
[WIP] Abstraction in custom post type plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ web/app/plugins/*
 !web/app/plugins/mitlib-post-exhibits
 !web/app/plugins/mitlib-post-experts
 !web/app/plugins/mitlib-post-locations
+!web/app/plugins/mitlib-post-notebooks
 !web/app/plugins/mitlib-pull-events
 !web/app/plugins/mitlib-pull-hours
 

--- a/web/app/mu-plugins/mitlib-post/src/class-base.php
+++ b/web/app/mu-plugins/mitlib-post/src/class-base.php
@@ -13,6 +13,51 @@ namespace Mitlib\PostTypes;
  */
 class Base {
 	/**
+	 * Generic define function that relies on constants defined in descendant
+	 * classes.
+	 */
+	public static function generic() {
+		$labels = array(
+			'name'                => _x( static::PLURAL, 'Post Type General Name', 'text_domain' ),
+			'singular_name'       => _x( static::SINGULAR, 'Post Type Singular Name', 'text_domain' ),
+			'menu_name'           => __( static::PLURAL, 'text_domain' ),
+			'name_admin_bar'      => __( static::SINGULAR, 'text_domain' ),
+			'parent_item_colon'   => __( static::SINGULAR, 'text_domain' ),
+			'all_items'           => __( 'All ' . static::PLURAL, 'text_domain' ),
+			'add_new_item'        => __( 'Add New ' . static::SINGULAR, 'text_domain' ),
+			'add_new'             => __( 'New ' . static::SINGULAR, 'text_domain' ),
+			'new_item'            => __( 'New ' . static::SINGULAR, 'text_domain' ),
+			'edit_item'           => __( 'Edit ' . static::SINGULAR, 'text_domain' ),
+			'update_item'         => __( 'Update ' . static::SINGULAR, 'text_domain' ),
+			'view_item'           => __( 'View ' . static::SINGULAR, 'text_domain' ),
+			'search_items'        => __( 'Search ' . static::PLURAL, 'text_domain' ),
+			'not_found'           => __( 'No ' . static::PLURAL . ' found', 'text_domain' ),
+			'not_found_in_trash'  => __( 'No ' . static::PLURAL . ' found in Trash', 'text_domain' ),
+		);
+		$args = array(
+			'label'               => __( static::SINGULAR, 'text_domain' ),
+			'description'         => __( static::SINGULAR, 'text_domain' ),
+			'labels'              => $labels,
+			'supports'            => array( 'title', 'editor', 'page-attributes', 'thumbnail' ),
+			'taxonomies'          => array( 'category', 'post_tag', 'event' ),
+			'hierarchical'        => true,
+			'public'              => true,
+			'show_ui'             => true,
+			'show_in_menu'        => true,
+			'menu_position'       => 6,
+			'menu_icon'           => 'dashicons-calendar-alt',
+			'show_in_admin_bar'   => true,
+			'show_in_nav_menus'   => true,
+			'can_export'          => true,
+			'has_archive'         => true,
+			'exclude_from_search' => false,
+			'publicly_queryable'  => true,
+			'capability_type'     => 'post',
+		);
+		register_post_type( strtolower( static::SINGULAR ), $args );
+	}
+
+	/**
 	 * Called during acf/settings/load_json
 	 *
 	 * @param Array $paths An array of paths where JSON files describing field

--- a/web/app/plugins/mitlib-post-notebooks/mitlib-post-notebooks.php
+++ b/web/app/plugins/mitlib-post-notebooks/mitlib-post-notebooks.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Plugin Name: MITlib Post Notebooks
+ * Description: Defines the custom Notebooks post type
+ * Version: 1.0.0
+ * Author: MIT Libraries
+ * License: GPL2
+ *
+ * @package MITlib Post Notebooks
+ * @author MIT Libraries
+ */
+
+namespace Mitlib\PostTypes;
+
+// Don't call the file directly!
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Require the necessary classes.
+require_once( plugin_dir_path( __FILE__ ) . 'src/class-notebook.php' );
+
+// Register class methods with the WordPress hooks which will call them.
+add_action( 'init', array( 'Mitlib\PostTypes\Notebook', 'generic' ) );
+add_filter( 'acf/settings/load_json', array( 'Mitlib\PostTypes\Notebook', 'load_point' ) );
+add_filter( 'acf/settings/save_json', array( 'Mitlib\PostTypes\Notebook', 'save_point' ) );

--- a/web/app/plugins/mitlib-post-notebooks/src/class-notebook.php
+++ b/web/app/plugins/mitlib-post-notebooks/src/class-notebook.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Class that defines the Notebooks custom post type, including fields.
+ *
+ * @package MITlib Post Notebooks
+ * @since 1.0.0
+ */
+
+namespace Mitlib\PostTypes;
+
+/**
+ * Defines the Notebook post type, used for richer, long-form blobs of text.
+ */
+class Notebook extends Base {
+	/**
+	 * The singular name of this post type.
+	 */
+	const SINGULAR = 'Notebook';
+
+	/**
+	 * The plural name of this post type.
+	 */
+	const PLURAL = 'Notebooks';
+}


### PR DESCRIPTION
This demonstrates an apparent way to get around the code repetition in the mitlib-post-FOO plugins which descend from the base mitlib-post plugin.

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
