### PR TITLE
News site updates based on internal review

### DIFF
--- a/web/app/mu-plugins/mitlib-post/data/bibliotech/group_54dd062c59653-2.json
+++ b/web/app/mu-plugins/mitlib-post/data/bibliotech/group_54dd062c59653-2.json
@@ -99,7 +99,7 @@
                 "operator": "==",
                 "value": "administrator"
             }
-        ],
+        ]
     ],
     "menu_order": 7,
     "position": "normal",

--- a/web/app/mu-plugins/mitlib-post/data/sitenews/group_54dd062c31627-1.json
+++ b/web/app/mu-plugins/mitlib-post/data/sitenews/group_54dd062c31627-1.json
@@ -1,5 +1,5 @@
 {
-    "key": "group_54dd062c31627",
+    "key": "group_54dd062c31627-1",
     "title": "Urgency flag (Post)",
     "fields": [
         {

--- a/web/app/mu-plugins/mitlib-post/data/spotlight/group_54dd062c31627-2.json
+++ b/web/app/mu-plugins/mitlib-post/data/spotlight/group_54dd062c31627-2.json
@@ -1,5 +1,5 @@
 {
-    "key": "group_54dd062c31627",
+    "key": "group_54dd062c31627-2",
     "title": "Urgency flag (Spotlights)",
     "fields": [
         {

--- a/web/app/plugins/mitlib-post-bibliotechs/src/class-bibliotech.php
+++ b/web/app/plugins/mitlib-post-bibliotechs/src/class-bibliotech.php
@@ -63,8 +63,8 @@ class Bibliotech extends Base {
 	 */
 	public static function taxonomies() {
 		$labels = array(
-			'name'                       => _x( 'Bibliotechs', 'Taxonomy General Name', 'text_domain' ),
-			'singular_name'              => _x( 'Bibliotech', 'Taxonomy Singular Name', 'text_domain' ),
+			'name'                       => _x( 'Bibliotech Issues', 'Taxonomy General Name', 'text_domain' ),
+			'singular_name'              => _x( 'Bibliotech Issue', 'Taxonomy Singular Name', 'text_domain' ),
 			'menu_name'                  => __( 'Issues', 'text_domain' ),
 			'all_items'                  => __( 'All Issues', 'text_domain' ),
 			'parent_item'                => __( 'Parent Issue', 'text_domain' ),

--- a/web/app/themes/mitlib-news/functions.php
+++ b/web/app/themes/mitlib-news/functions.php
@@ -69,6 +69,19 @@ function admin_styles() {
 add_action( 'admin_head', 'Mitlib\News\admin_styles' );
 
 /**
+ * Add custom images for the news.
+ *
+ * @uses add_theme_support() To enable the theme's support for custom header
+ *                           images.
+ * @uses add_image_size() Registers a new image size for use by the theme.
+ */
+add_theme_support( 'post-thumbnails' );
+add_image_size( 'news-home', 111, 206, true ); // Hard Crop Mode.
+add_image_size( 'news-listing', 323, 111, true ); // Hard Crop Mode.
+add_image_size( 'news-feature', 657, 256, true ); // Hard Crop Mode.
+add_image_size( 'news-single', 451, 651, true ); // Hard Crop Mode.
+
+/**
  * Remove parent theme page templates.
  *
  * The Parent theme includes a number of page templates which are meant for only


### PR DESCRIPTION
This resolves the problems identified during a close review of the needed workflows in the News site. Specically, each of the following changes are made in one commit each:

- The name of the controlled vocabulary for issues of the Bibliotech is updated to be "Bibliotech Issues" - to prevent confusion between that and the actual "Bibliotech" content type.
- A few specific image sizes / formats are added from the legacy theme, which makes it easier for content authors to accurately apply those image sizes while writing articles.
- A few field groups are updated to make sure that all the needed fields are actually appearing (two field groups were not visible because of a name collision, and some invalid JSON)

## Ticket

https://mitlibraries.atlassian.net/browse/LM-300

## Developer

### Secrets

- [x] No secrets are affected

### Documentation

- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
