### PR TITLE
Remove facebook and rss from footer

### DIFF
--- a/web/app/themes/mitlib-parent/css/scss/partials/_footer.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_footer.scss
@@ -125,6 +125,7 @@
 		flex-wrap: wrap;
 		padding-left: 1.375em;
 		width: auto;
+		min-width: 12em;
 		@include bp-tablet--portrait {
 			flex-wrap: nowrap;
 			margin-bottom: .2em;

--- a/web/app/themes/mitlib-parent/inc/footer-main.php
+++ b/web/app/themes/mitlib-parent/inc/footer-main.php
@@ -67,11 +67,6 @@ namespace Mitlib\Parent;
 					<span class="sr">Twitter</span>
 				</a><!-- End Twitter -->
 
-				<a href="https://www.facebook.com/mitlib" title="Facebook">
-					<svg class="icon-social--facebook" width="2048" height="2048" viewBox="-640 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M511 980h257l-30 -284h-227v-824h-341v824h-170v284h170v171q0 182 86 275.5t283 93.5h227v-284h-142q-39 0 -62.5 -6.5t-34 -23.5t-13.5 -34.5t-3 -49.5v-142z" fill="black" /></g></svg>
-					<span class="sr">Facebook</span>
-				</a><!-- End Facebook -->
-
 				<a href="https://instagram.com/mitlibraries/" title="Instagram">
 					<svg class="icon-social--instagram" viewBox="0 0 120 120" enable-background="new 0 0 120 120" xml:space="preserve"><path id="Instagram_10_" fill="#FFFFFF" d="M95.1,103.9H24.9c-0.2,0-0.4-0.1-0.6-0.1c-3.9-0.5-7.1-3.4-8-7.2
 c-0.1-0.4-0.2-0.9-0.2-1.3V24.8c0-0.2,0.1-0.3,0.1-0.5c0.6-3.9,3.4-7.1,7.3-8c0.4-0.1,0.8-0.2,1.3-0.2h70.4c0.2,0,0.3,0.1,0.5,0.1
@@ -83,18 +78,12 @@ c-8.5,5.8-19.6,6.3-28.6,1.2c-4.5-2.5-8.1-6.1-10.6-10.7c-3.7-6.8-4.3-14-2.1-21.4C
  M86.7,38.7L86.7,38.7c1.4,0,2.9,0,4.3,0c1.9,0,3.4-1.6,3.4-3.5c0-2.8,0-5.5,0-8.3c0-2-1.6-3.6-3.6-3.6c-2.8,0-5.5,0-8.3,0
 c-2,0-3.6,1.6-3.6,3.6c0,2.7,0,5.5,0,8.2c0,0.4,0.1,0.8,0.2,1.2c0.5,1.5,1.8,2.4,3.5,2.4C84,38.7,85.3,38.7,86.7,38.7L86.7,38.7z"/></svg>
 					<span class="sr">Instagram</span>
-
 				</a><!-- End Instagram -->
 
 				<a href="https://www.youtube.com/user/MITLibraries" title="YouTube">
 					<svg aria-hidden="true" focusable="false" data-prefix="fab" data-icon="youtube" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512" class="icon-social--youtube"><path fill="black" d="M549.655 124.083c-6.281-23.65-24.787-42.276-48.284-48.597C458.781 64 288 64 288 64S117.22 64 74.629 75.486c-23.497 6.322-42.003 24.947-48.284 48.597-11.412 42.867-11.412 132.305-11.412 132.305s0 89.438 11.412 132.305c6.281 23.65 24.787 41.5 48.284 47.821C117.22 448 288 448 288 448s170.78 0 213.371-11.486c23.497-6.321 42.003-24.171 48.284-47.821 11.412-42.867 11.412-132.305 11.412-132.305s0-89.438-11.412-132.305zm-317.51 213.508V175.185l142.739 81.205-142.739 81.201z" class=""></path></svg>
 					<span class="sr">YouTube</span>
 				</a><!-- End YouTube -->
-
-				<a href="https://libguides.mit.edu/mit-feeds" title="RSS">
-					<svg class="icon-social--rss" width="2048" height="2048" viewBox="-320 -384 2048 2048" xmlns="http://www.w3.org/2000/svg"><g transform="scale(1 -1) translate(0 -1280)"><path d="M384 192q0 -80 -56 -136t-136 -56t-136 56t-56 136t56 136t136 56t136 -56t56 -136zM896 69q2 -28 -17 -48q-18 -21 -47 -21h-135q-25 0 -43 16.5t-20 41.5q-22 229 -184.5 391.5t-391.5 184.5q-25 2 -41.5 20t-16.5 43v135q0 29 21 47q17 17 43 17h5q160 -13 306 -80.5 t259 -181.5q114 -113 181.5 -259t80.5 -306zM1408 67q2 -27 -18 -47q-18 -20 -46 -20h-143q-26 0 -44.5 17.5t-19.5 42.5q-12 215 -101 408.5t-231.5 336t-336 231.5t-408.5 102q-25 1 -42.5 19.5t-17.5 43.5v143q0 28 20 46q18 18 44 18h3q262 -13 501.5 -120t425.5 -294 q187 -186 294 -425.5t120 -501.5z" fill="black" /></g></svg>
-					<span class="sr">RSS</span>
-				</a><!-- End RSS -->
 
 		</div><!-- end div.social -->
 


### PR DESCRIPTION
Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/UXWS-1511

How does this address that need:

* Removes the two links

Document any side effects to this change:

* A css rule was updated to keep similar sizing when moving from 5 to 3 elements in the flexbox. The rails apps did not need this, but since they use a different grid altogether this may not be unexpected.

## Developer

### Secrets

- [x] All new secrets have been added to Pantheon tiers
- [x] Relevant secrets have been updated in Github Actions
- [x] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
