### PR TITLE
Updates 404 page content

### DIFF
--- a/web/app/themes/mitlib-parent/404.php
+++ b/web/app/themes/mitlib-parent/404.php
@@ -27,7 +27,7 @@ get_header();
 					<?php } else { ?>
 
 						<header class="entry-header">
-							<h1 class="entry-title">The requested content was not found.</h1>
+							<h1 class="entry-title">Sorry, that link doesn’t work anymore. Get help below!</h1>
 						</header>
 						<?php get_template_part( 'inc/site-search' ); ?>
 

--- a/web/app/themes/mitlib-parent/inc/site-search.php
+++ b/web/app/themes/mitlib-parent/inc/site-search.php
@@ -20,18 +20,14 @@
 		</div>
 	</form>
 
-	<h2>Browse our <a href="/site-search">A-Z index of pages</a> on this site.</h2>
+	<h2>Need help? <a href="/ask">Ask us!</a></h2>
 
-	<p>You can also check out these commonly-used resources:</p>
-
+	<p>Or try:</p>
 	<ul>
-		<li><a href="//libraries.mit.edu/quicksearch">Quick search: Books, articles, &amp; more at MIT</a></li>
-		<li><a href="//libguides.mit.edu/directory">Staff directory</a></li>
-		<li><a href="/research-guides">Research guides - databases by subject</a></li>
-		<li><a href="/shortcuts/">Shortcuts to frequently used pages</a></li>
+		<li><a href="/search">Quick search: Books, articles, films, archival material, and more</a></li>
+		<li><a href="/research-guides">Research guides &amp; expert librarians</a></li>
 		<li><a href="//web.mit.edu/search.html">MIT web site search</a></li>
 	</ul>
 
-	<p><a href="/ask">Need more help? Ask us!</a></p>
 
 </div><!-- .entry-content -->

--- a/web/app/themes/mitlib-parent/search.php
+++ b/web/app/themes/mitlib-parent/search.php
@@ -2,6 +2,12 @@
 /**
  * The template for displaying Search Results pages.
  *
+ * We generally don't rely on this template for _most_ of our site search.
+ * However, the template remains to handle built in search functionality in
+ * WordPress.
+ *
+ * Example link that uses this template: `/?s=keyword`
+ *
  * @package MITlib_Parent
  * @since 0.2.0
  */


### PR DESCRIPTION
Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/LM-270

How does this address that need:

* Updates markup to match requested changes in linked ticket

Document any side effects to this change:

The 404 template and the default search results template both share the same search form partial. We don't generally expect the default search template to be used, but the changes to 404 do cause that to update as well.

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
