### PR TITLE
Pin cf7-conditional-fields to 2.2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
     "wpackagist-plugin/akismet": "^5.0",
     "wpackagist-plugin/antivirus": "^1.4",
     "wpackagist-plugin/black-studio-tinymce-widget": "^2.7",
-    "wpackagist-plugin/cf7-conditional-fields": "^2.2",
+    "wpackagist-plugin/cf7-conditional-fields": "2.2.3",
     "wpackagist-plugin/cf7-to-zapier": "^2.2",
     "wpackagist-plugin/classic-editor": "^1.6",
     "wpackagist-plugin/classic-widgets": "^0.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcde7db1616f5eef151f241c0b1f6d65",
+    "content-hash": "8e7b2660a6b646edadb564198eb59d1d",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -2828,15 +2828,15 @@
         },
         {
             "name": "wpackagist-plugin/cf7-conditional-fields",
-            "version": "2.3.4",
+            "version": "2.2.3",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/cf7-conditional-fields/",
-                "reference": "tags/2.3.4"
+                "reference": "tags/2.2.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/cf7-conditional-fields.2.3.4.zip"
+                "url": "https://downloads.wordpress.org/plugin/cf7-conditional-fields.2.2.3.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -2918,15 +2918,15 @@
         },
         {
             "name": "wpackagist-plugin/contact-form-7",
-            "version": "5.7.4",
+            "version": "5.7.5.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/contact-form-7/",
-                "reference": "tags/5.7.4"
+                "reference": "tags/5.7.5.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/contact-form-7.5.7.4.zip"
+                "url": "https://downloads.wordpress.org/plugin/contact-form-7.5.7.5.1.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
Versions above this are incompatible with something in our system, likely our ancient jQuery version.

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
