### PR TITLE
Update experts API endpoint to contain image URLs in featured_media field

### DIFF
--- a/web/app/themes/mitlib-parent/functions.php
+++ b/web/app/themes/mitlib-parent/functions.php
@@ -262,7 +262,7 @@ add_action( 'customize_preview_init', 'Mitlib\Parent\customize_preview_js' );
  * @link http://v2.wp-api.org/extending/modifying/
  * @link https://gist.github.com/rileypaulsen/9b4505cdd0ac88d5ef51#gistcomment-1622466
  */
-function mitlib_api_alter() {
+function api_alter() {
 	// Add custom fields to posts endpoint.
 	register_rest_field(
 		'post',
@@ -278,8 +278,19 @@ function mitlib_api_alter() {
 			'schema'          => null,
 		)
 	);
+
+	// Switch featured_media field from media ID to URL of the image.
+	register_rest_field(
+		'experts',
+		'featured_media',
+		array(
+			'get_callback'    => 'Mitlib\Parent\api_get_image',
+			'update_callback' => null,
+			'schema'          => null,
+		)
+	);
 }
-add_action( 'rest_api_init', 'Mitlib\Parent\mitlib_api_alter' );
+add_action( 'rest_api_init', 'Mitlib\Parent\api_alter' );
 
 /**
  * Registers our main widget areas.
@@ -417,6 +428,20 @@ add_filter( 'body_class', 'Mitlib\Parent\customize_body_class' );
  * These functions are defined here, without adding them via add_action. They
  * may be called by the templates within the theme.
  */
+
+/**
+ * Get the value of a specified field for use in the API. This function is
+ * called by api_alter above
+ *
+ * @param array  $object Details of current post.
+ * @param string $field_name Name of field.
+ *
+ * @return mixed
+ */
+function api_get_image( $object, $field_name ) {
+	$link = wp_get_attachment_image_src( $object[ $field_name ], 'thumbnail-size' );
+	return $link[0];
+}
 
 /**
  * Provides an alternative way for building a breadcrumb.


### PR DESCRIPTION
** Why are these changes being introduced:

* The experts endpoint in the API has a featured_media field, which by default is returned as the ID of the image in that field. However, the legacy platform has overridden this value to be the URL for the image instead, so that the homepage doesn't need to perform a second call in order to load the image.

** Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-304

** How does this address that need:

* This brings forward the api_get_image function from the legacy parent theme, which replaces the image ID with just the URL to the image size we need (for the experts endpoint only)

** Document any side effects to this change:

* The behavior of the experts endpoint is now different from others, like the pages or posts endpoint. The featured_media field is a URL in one, but still the image ID in others.

## Developer

### Secrets

- [x] No secrets are affected

### Documentation

- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been given

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
