### PR TITLE
Fix map template on parent theme

### DIFF
--- a/web/app/themes/mitlib-parent/functions.php
+++ b/web/app/themes/mitlib-parent/functions.php
@@ -28,6 +28,16 @@ require_once( 'navwalker.php' );
 require_once( 'lib/news.php' );
 
 /**
+ * Define custom query params. Right now this is just the `v` parameter used by
+ * the map template.
+ */
+function register_params() {
+	global $wp;
+	$wp->add_query_var( 'v' );
+}
+add_action( 'init', 'Mitlib\Parent\register_params' );
+
+/**
  * Sets up theme defaults and registers the various WordPress features that it
  * supports. This was function was borrowed from Twenty Twelve.
  *

--- a/web/app/themes/mitlib-parent/inc/content-location-2021.php
+++ b/web/app/themes/mitlib-parent/inc/content-location-2021.php
@@ -8,7 +8,7 @@
 
 namespace Mitlib\Parent;
 
-global $gStudy24Url;
+$gStudy24Url = '/study/24x7/';
 
 $mapPage = '/locations/#!';
 

--- a/web/app/themes/mitlib-parent/inc/content-location.php
+++ b/web/app/themes/mitlib-parent/inc/content-location.php
@@ -8,7 +8,7 @@
 
 namespace Mitlib\Parent;
 
-	global $gStudy24Url;
+	$gStudy24Url = '/study/24x7/';
 
 	$mapPage = '/locations/#!';
 

--- a/web/app/themes/mitlib-parent/templates/page-map-locations.php
+++ b/web/app/themes/mitlib-parent/templates/page-map-locations.php
@@ -18,6 +18,8 @@ if ( 'map' == $v ) {
 	$show_map = 1;
 }
 
+$gStudy24Url = '/study/24x7/';
+
 get_header(); ?>
 	<script>
 		var showMap = <?php echo esc_js( $show_map ); ?>;

--- a/web/app/themes/mitlib-parent/templates/page-map-locations.php
+++ b/web/app/themes/mitlib-parent/templates/page-map-locations.php
@@ -82,8 +82,10 @@ get_header(); ?>
 							$name = html_entity_decode( get_the_title() );
 
 							$displayPage = get_field( 'display_page' );
-							$pageID = $displayPage->ID;
-							$pageLink = get_permalink( $pageID );
+							$pageLink = get_permalink( $post );
+							if ( 'object' == gettype( $displayPage ) ) {
+								$pageLink = get_permalink( $displayPage->ID );
+							}
 							$directionsUrl = 'http://maps.google.com/maps?';
 							$directionsUrl .= 'daddr=' . $lat . ',' . $lng;
 							if ( $lat != '' && $lng != '' ) :
@@ -150,8 +152,10 @@ get_header(); ?>
 							$study24 = get_field( 'study_24' );
 
 							$displayPage = get_field( 'display_page' );
-							$pageID = $displayPage->ID;
-							$pageLink = get_permalink( $pageID );
+							$pageLink = get_permalink( $post );
+							if ( 'object' == gettype( $displayPage ) ) {
+								$pageLink = get_permalink( $displayPage->ID );
+							}
 
 							$temp = $post;
 							$post = $temp;
@@ -209,8 +213,10 @@ get_header(); ?>
 						$post = $temp;
 
 						$displayPage = get_field( 'display_page' );
-						$pageID = $displayPage->ID;
-						$pageLink = get_permalink( $pageID );
+						$pageLink = get_permalink( $post );
+						if ( 'object' == gettype( $displayPage ) ) {
+							$pageLink = get_permalink( $displayPage->ID );
+						}
 						?>
 						<li class="location-secondary">
 							<?php if ( 'stata' === $slug || 'building-9' === $slug ) : ?>

--- a/web/app/themes/mitlib-parent/templates/page-map-locations.php
+++ b/web/app/themes/mitlib-parent/templates/page-map-locations.php
@@ -12,13 +12,15 @@
 
 namespace Mitlib\Parent;
 
-// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated -- need to properly receive 'v' parameter.
-$showMap = ( $_GET['v'] != '' ) && ( $_GET['v'] == 'map' ) ? 1 : 0;
-// phpcs:enable
+$v = get_query_var( 'v' );
+$show_map = 0;
+if ( 'map' == $v ) {
+	$show_map = 1;
+}
 
 get_header(); ?>
 	<script>
-		var showMap = <?php echo esc_js( $showMap ); ?>;
+		var showMap = <?php echo esc_js( $show_map ); ?>;
 	</script>	
 
 		<?php get_template_part( 'inc/breadcrumbs' ); ?>

--- a/web/app/themes/mitlib-parent/templates/page-map-locations.php
+++ b/web/app/themes/mitlib-parent/templates/page-map-locations.php
@@ -57,13 +57,15 @@ get_header(); ?>
 
 							$mapImage = get_field( 'map_image' );
 
+							$val = '';
 							for ( $i = 1;$i <= $numMain;$i++ ) {
 								$img = get_field( 'main_image' . $i, $locationId );
 								if ( $img != '' ) {
 									$arMain[] = $img; }
 							}
-							$val = $arMain[ array_rand( $arMain ) ];
-							// $val = $arMain[0];
+							if ( 0 < count( $arMain ) ) {
+								$val = $arMain[ array_rand( $arMain ) ];
+							}
 							if ( $mapImage != '' ) {
 								// user override image.
 								$val = $mapImage;

--- a/web/app/themes/mitlib-parent/templates/page-study-spaces.php
+++ b/web/app/themes/mitlib-parent/templates/page-study-spaces.php
@@ -14,6 +14,8 @@
 
 namespace Mitlib\Parent;
 
+$gStudy24Url = '/study/24x7/';
+
 get_header(); ?>
 
 		<?php get_template_part( 'inc/breadcrumbs' ); ?>


### PR DESCRIPTION
Ticket:  https://mitlibraries.atlassian.net/browse/LM-306

This makes the map template into something usable. Specific changes here are:

* Fixes how a `$val` variable is being assigned within the map template, only picking a random value from an array if that array is not empty - this is used to pick a thumbnail to represent a location when multiple images have been uploaded.
* Replaces a global `$gStudy24Url` variable which used to be defined in functions.php, instead defining the variable on the templates which need it. More details and a reference URL are in that commit message.
* Improves how a `v` parameter is defined and handled by the map template (was throwing a warning)
* Updates how the `$pageLink` variable is calculated, preventing a scenario where we were trying to extract object properties from a boolean value. The new logic sets `$pageLink` based on the location record as a default, and then overrides that if the location record has been assigned to display at a given page location. (This construct appears three times on the map page template).

**Please note** CodeClimate is flagging the use of variable names that don't follow snake_case naming conventions. Starting to make those changes now will, I fear, start touching more and more lines in the template, which will end in a general rebuild of the template. I don't think that I have time for that, for as much as it would carry some advantages.

## Developer

### Secrets

- [x] No secrets are impacted by this work.

### Documentation

- [x] No documentation changes are made.

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
