### PR TITLE
Adds styles specific to 2021 location template

### DIFF
--- a/web/app/themes/mitlib-parent/css/scss/partials/_locations.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_locations.scss
@@ -74,6 +74,44 @@
 			}
 }
 
+// The 2021 location template adjusts column widths because the sidebar is not
+// loaded.
+.locationPage.page-template-page-location-2021 {
+	// This matches the left-margin that is used throughout the site.
+	.main-content {
+		padding-right: 27.5px;
+	}
+	.tab {
+		.first {
+			@include bp-tablet--portrait {
+				width: 33%;
+			}
+		}
+		.second {
+			max-width: 540px;
+			@include bp-tablet--portrait {
+				width: 66%;
+			}
+
+			.featured-location {
+				margin-top: 36px;
+
+				// This overrides default .alignleft styling which has 1em top
+				// margin.
+				img.alignleft {
+					margin-top: 0;
+				}
+			}
+		}
+	}
+	// This repeats a media-queried rule from _tabs.scss, for all screens.
+	.tabcontent {
+		border-top: 1px solid #dedede;
+		padding-top: 20px;
+		clear: both;
+	}
+}
+
 .page-locations {
 	.location-name {
 		padding-bottom: 15px;
@@ -274,6 +312,18 @@
 }
 
 /* ---- Responsive Styles ---- */
+@media screen and (max-width: 820px) {
+	.page-template-page-location-2021 {
+		.second {
+			.featured-location {
+				.alignleft {
+					float: inherit;
+				}
+			}
+		}
+	}
+}
+
 @media screen and (min-width: 569px) and (max-width: 820px) {
 	.locationPage {
 		.profile-content {


### PR DESCRIPTION
**Why are these changes being introduced:**

The set of parent theme styles was apparently created without those which apply to the 2021 location template.

**Relevant ticket(s):**

https://mitlibraries.atlassian.net/browse/lm-305

**How does this address that need:**

This brings up the block of styles for that template.

**Document any side effects to this change:**

None for this change, but I'm trying to understand how these styles (and some other more recent changes to the theme) were missed during the initial theme build-out. I wonder whether my copy of the parent theme was somehow behind the main branch at the time.

## Developer

### Secrets

- [x] No secrets are affected

### Documentation

- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
