### PR TITLE
Adds a how-to page for promoting css changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,10 @@
 ## Developer
 
+### Stylesheets
+
+- [ ] Any theme or plugin whose stylesheets have changed has had its version
+      string incremented.
+
 ### Secrets
 
 - [ ] All new secrets have been added to Pantheon tiers

--- a/docs/howto/promote-css-changes.md
+++ b/docs/howto/promote-css-changes.md
@@ -1,4 +1,4 @@
-# How to promote CSS changes to Live with minimal pain
+# How to make CSS changes with minimal pain
 
 This document describes the best workflow for promoting changes to CSS styles
 to the Live tier in Pantheon, in such a way that they take effect relatively
@@ -25,56 +25,46 @@ affects any stylesheet in the themes.
 These steps should be followed when making the change to either the Live or Test
 tiers.
 
+## During development
+
+**If your change involves updates to any theme stylesheet, make sure that you
+increment the theme version.**
+
+The theme version can be found in the block comment at the top of the theme's
+`style.css` file. This string is used as a cache-busting technique when loading
+stylesheets, prompting users' browsers to download a fresh copy of the file
+when warranted.
+
 ## The procedure
 
 1. Deploy the change via the Code tab on the Pantheon dashboard.
-2. In your browser, load a page which should be impacted by the new CSS styles.
-   At this point, the change should not yet be visible.
-3. Using the developer tools in your browser, identify and directly load the
+2. Clear the caches within Pantheon (via either the web UI or Terminus).
+3. In your browser, load a page which should be impacted by the new CSS styles.
+
+If your change is visible at this point, you can skip the rest of this workflow.
+If the change is not yet visible, the following steps may help:
+
+4. Using the developer tools in your browser, identify and directly load the
    compiled stylesheet which holds the updated rules. For the parent theme, this
    will likely be `global.css`, which is compiled using the WP-SCSS plugin.
-4. Within that stylesheet, identify whether the style change can be identified.
+5. Within that stylesheet, identify whether the style change can be identified.
    If the new styles are not yet visible, continue with this procedure (if the
    styles have been updated and the rendering is still incorrect, there may be a
    bug which requires further development).
-5. Log into WordPress, go to the WP-SCSS settings page, and turn on the "Always
+6. Log into WordPress, go to the WP-SCSS settings page, and turn on the "Always
    Recompile" option. This setting is off by default on the Test and Live tiers
    for performance reasons.
-6. Use the Pantheon dashboard to clear caches for that tier.
-7. Wait for a minute or two, to give the caches time to fully clear. This can be
-   monitored using the "Workflows" modal on the dashboard.
-8. Force-reload the compiled stylesheet opened in step 3. Confirm that the
+7. Clear the caches within Pantheon again.
+8. Wait for a minute or two, to give the caches time to fully clear. This can be
+   monitored using the "Workflows" modal on the Pantheon dashboard.
+9. Force-reload the compiled stylesheet opened in step 3. Confirm that the
    updated styles are now included.
-9. Force-reload the reference page again (from step 2), and check that the
-   intended change is now visible.
-10. Once you have seen the change in action, turn off the "Always Recompile"
+10. Force-reload the reference page again (from step 2), and check that the
+    intended change is now visible.
+11. Once you have seen the change in action, turn off the "Always Recompile"
     setting from step 5.
 
-## A possible roadmap of future adjustments
+## For more information
 
-WordPress has a mechanism for helping to cache-bust this sort of system, which
-might be adopted as part of our workflows in the future. In the parent theme,
-the line which registers the global stylesheet uses the theme version as a
-URL parameter:
-
-**style.css**
-```css
-/*
-Theme Name: MITlib Parent
-Author: MIT Libraries
-Version: 0.2.1
-Description: The parent theme for the MIT Libraries' Pentagram-designed identity.
-```
-
-**functions.php**
-```php
-$theme_version = wp_get_theme()->get( 'Version' );
-
-wp_register_style( 'parent-global', get_template_directory_uri() . '/css/build/global.css', array( 'parent-styles', 'font-open-sans' ), $theme_version );
-```
-
-Incrementing the theme version in style.css during development should help
-browsers to update their caches.
-
-_A possible future adjustment to this process would be to include the theme
-version in the filename itself, rather than just the querystring._
+Please see the reference article [How our themes use stylesheets](https://github.com/MITLibraries/mitlib-wp-network/blob/master/docs/reference/theme-styles.md) for an overview of our approach to
+styling WordPress.

--- a/docs/howto/promote-css-changes.md
+++ b/docs/howto/promote-css-changes.md
@@ -1,0 +1,80 @@
+# How to promote CSS changes to Live with minimal pain
+
+This document describes the best workflow for promoting changes to CSS styles
+to the Live tier in Pantheon, in such a way that they take effect relatively
+quickly and without confusion about whether things worked.
+
+## Why this is necessary
+
+Promoting changes to CSS stylesheets can be a tricky proposition, because the
+files involved can be cached in many different places. Additionally, many of
+our stylesheets are compiled via SCSS - but this does not happen on every page
+load on the Test and Live tiers, because it raises performance problems.
+
+As a result, there can at times be a significant delay between deploying a new
+set of styles and seeing those changes reflected in users' browsers.
+
+Following the steps below may not eliminate that delay entirely, but should help
+reduce it.
+
+## When to follow these steps
+
+Follow this procedure whenever a change in being promoted on Pantheon which
+affects any stylesheet in the themes.
+
+These steps should be followed when making the change to either the Live or Test
+tiers.
+
+## The procedure
+
+1. Deploy the change via the Code tab on the Pantheon dashboard.
+2. In your browser, load a page which should be impacted by the new CSS styles.
+   At this point, the change should not yet be visible.
+3. Using the developer tools in your browser, identify and directly load the
+   compiled stylesheet which holds the updated rules. For the parent theme, this
+   will likely be `global.css`, which is compiled using the WP-SCSS plugin.
+4. Within that stylesheet, identify whether the style change can be identified.
+   If the new styles are not yet visible, continue with this procedure (if the
+   styles have been updated and the rendering is still incorrect, there may be a
+   bug which requires further development).
+5. Log into WordPress, go to the WP-SCSS settings page, and turn on the "Always
+   Recompile" option. This setting is off by default on the Test and Live tiers
+   for performance reasons.
+6. Use the Pantheon dashboard to clear caches for that tier.
+7. Wait for a minute or two, to give the caches time to fully clear. This can be
+   monitored using the "Workflows" modal on the dashboard.
+8. Force-reload the compiled stylesheet opened in step 3. Confirm that the
+   updated styles are now included.
+9. Force-reload the reference page again (from step 2), and check that the
+   intended change is now visible.
+10. Once you have seen the change in action, turn off the "Always Recompile"
+    setting from step 5.
+
+## A possible roadmap of future adjustments
+
+WordPress has a mechanism for helping to cache-bust this sort of system, which
+might be adopted as part of our workflows in the future. In the parent theme,
+the line which registers the global stylesheet uses the theme version as a
+URL parameter:
+
+**style.css**
+```css
+/*
+Theme Name: MITlib Parent
+Author: MIT Libraries
+Version: 0.2.1
+Description: The parent theme for the MIT Libraries' Pentagram-designed identity.
+```
+
+**functions.php**
+```php
+$theme_version = wp_get_theme()->get( 'Version' );
+
+wp_register_style( 'parent-global', get_template_directory_uri() . '/css/build/global.css', array( 'parent-styles', 'font-open-sans' ), $theme_version );
+```
+
+Incrementing the theme version in style.css during development should help
+browsers to update their caches.
+
+_A possible future adjustment to this process would be to include the theme
+version in the filename itself, rather than just the querystring._

--- a/docs/reference/theme-styles.md
+++ b/docs/reference/theme-styles.md
@@ -1,0 +1,77 @@
+# How our themes use stylesheets
+
+## Types of stylesheets
+
+The themes we maintain have multiple sets of stylesheets.
+
+1. The main static stylesheet
+2. Component stylesheets
+3. Any compiled stylesheets
+
+### Main stylesheet
+
+A theme's main stylesheet is named `style.css`, and is found in the root of the
+theme folder.
+
+#### Theme Metadata
+
+This stylesheet, in addition to whatever CSS rules it defines, includes a
+comment block at the top of the file. This block is used by WordPress itself to
+define certain information about theme as a whole - including the current
+version of the theme.
+
+Full documentation about this feature can be found in the Theme Handbook at:
+https://developer.wordpress.org/themes/basics/main-stylesheet-style-css/
+
+### Component stylesheets
+
+Some stylesheets may only need to be loaded in certain conditions (by specific
+templates, or when certain content conditions are met). These component-based
+stylesheets can be found in the `css/` folder within each theme.
+
+An example of this approach was the `super-admin.css` stylesheet, which was used
+in the Parent theme to load certain styles that would only be seen by super
+admin users (this stylesheet has been retired).
+
+### Compiled stylesheets
+
+Some component stylesheets end up being complex enough that we leverage SASS to
+compile them. These SCSS files, if used, can be found under the `css/scss/`
+folder within each theme.
+
+The tool we use to compile these stylesheets is the [WP-SCSS plugin](https://wordpress.org/plugins/wp-scss/).
+
+## Registering and enqueuing
+
+Stylesheets, of any type, are attached to a page via a block of code in the
+theme's `functions.php` file. This code should be found in a function called by
+the `wp_enqueue_scripts` action.
+
+The structure of this function should be structured like this:
+
+```php
+function scripts_styles() {
+	// Look up theme version
+	$theme_version = wp_get_theme()->get( 'Version' );
+
+	// Register all known stylesheets
+	wp_register_style( 'parent-styles', get_stylesheet_uri(), array(), $theme_version );
+	wp_register_style( 'parent-global', get_template_directory_uri() . '/css/build/global.css', array( 'parent-styles' ), $theme_version );
+
+	wp_register_style( 'super-admin', get_template_directory_uri() . '/css/super-admin.css', array(), $theme_version, false );
+
+	// Globally enqueue the base styles
+	wp_enqueue_style( 'parent-global' );
+
+	// Conditionally enqueue stylesheets as needed
+	if ( is_super_admin() ) {
+		wp_enqueue_style( 'super-admin' );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'Name\Space\scripts_styles' );
+```
+
+Please refer to the [WordPress code reference](https://developer.wordpress.org/reference/) for more information about the
+functions used in the above example, especially:
+* [wp_enqueue_style](https://developer.wordpress.org/reference/functions/wp_enqueue_style/)
+* [wp_register_style](https://developer.wordpress.org/reference/functions/wp_register_style/)


### PR DESCRIPTION
**Why are these changes being introduced:**

* The process of making sure that CSS changes take effect quickly, and identifying whether a deploy has been successful, is somewhat tricky because of the SCSS compilation process, combined with aggressive browser caching.

**Relevant ticket(s):**

* https://mitlibraries.atlassian.net/browse/lm-278

**How does this address that need:**

* This documents the best workflow we've yet found for promoting CSS changes and forcing them to take effect on the Test and Live tiers.
* The how-to document also includes a brief discussion of some future process changes that we could adopt, which might make these steps less necessary in the future.

**Document any side effects to this change:**

* This is just documentation changes, so there should be no side effects.

## Developer

### Secrets

- [ ] No secrets are affected

### Documentation

- [ ] Project documentation has been updated

### Accessibility

- [ ] There are no accessibility-related changes (documentation only)

### Stakeholder approval

- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
