### PR TITLE
Refactor how timezones are applied during event pull

### DIFF
--- a/web/app/plugins/mitlib-pull-events/class-pull-events-plugin.php
+++ b/web/app/plugins/mitlib-pull-events/class-pull-events-plugin.php
@@ -103,19 +103,6 @@ class Pull_Events_Plugin {
 	 *                         error log.
 	 */
 	public static function pull_events( $confirm = false ) {
-
-		/**
-		 * Before we do anything, make sure our timezone is set correctly based on
-		 * the site settings. Ideally we would store times and dates in their proper
-		 * format, but it was a legacy decision that they would be stored as
-		 * strings, rather than datetimes.
-		 *
-		 * TODO: Fix this more fundamentally.
-		 */
-		// phpcs:disable WordPress.DateTime.RestrictedFunctions.timezone_change_date_default_timezone_set -- temporarily ignore this problem.
-		date_default_timezone_set( get_option( 'timezone_string' ) );
-		// phpcs:enable -- begin scanning normally again.
-
 		$url = EVENTS_URL;
 		$result = file_get_contents( $url );
 		$events = json_decode( $result, true );
@@ -132,14 +119,18 @@ class Pull_Events_Plugin {
 					$calendar_id = $val['event']['event_instances'][0]['event_instance']['id'];
 					$start = strtotime( $val['event']['event_instances'][0]['event_instance']['start'] );
 					$startdate = gmdate( 'Ymd', $start );
-					$starttime = gmdate( 'h:i A', $start );
+					$workingtime = new DateTime( gmdate( 'h:i A', $start ) );
+					$workingtime->setTimezone( new DateTimeZone( get_option( 'timezone_string' ) ) );
+					$starttime = $workingtime->format( 'h:i A' );
 					$end = '';
 					$enddate = '';
 					$endtime = '';
 					if ( isset( $val['event']['event_instances'][0]['event_instance']['end'] ) ) {
 						$end = strtotime( $val['event']['event_instances'][0]['event_instance']['end'] );
 						$enddate = gmdate( 'Ymd', $end );
-						$endtime = gmdate( 'h:i A', $end );
+						$workingtime = new DateTime( gmdate( 'h:i A', $end ) );
+						$workingtime->setTimezone( new DateTimeZone( get_option( 'timezone_string' ) ) );
+						$endtime = $workingtime->format( 'h:i A' );
 					}
 				}
 				if ( isset( $val['event']['localist_url'] ) ) {


### PR DESCRIPTION
This refactors how event times are processed during import. The legacy approach (used on both the legacy AWS infrastructure as well as the Pantheon/Lando containers) relied on a WordPress-focused approach. While that worked on our AWS environment, it didn't have the same results in Pantheon/Lando.

As an alternative, this change focuses on a PHP-centric approach to time calculations - which I suspect is working because it doesn't rely on the container itself being set to any particular timezone.

## Developer

### Secrets

- [x] No secrets are affected

### Documentation

- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
