### PR TITLE
Add moment and underscore libs to child theme

### DIFF
--- a/web/app/themes/mitlib-child/functions.php
+++ b/web/app/themes/mitlib-child/functions.php
@@ -35,6 +35,8 @@ function child_scripts_styles() {
 	wp_deregister_script( 'jquery' );
 	wp_register_script( 'jquery', '//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js', array(), '1.9.1', true );
 	wp_register_script( 'bootstrap-js', '//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js', array( 'jquery' ), '3.0.0' );
+	wp_register_script( 'moment', get_template_directory_uri() . '/js/libs/moment.min.js', array(), $theme_version, true );
+	wp_register_script( 'underscore', get_template_directory_uri() . '/js/libs/underscore.min.js', array(), $theme_version, true );
 
 	// Finally we enqueue those libraries - the child theme just always enqueues everything.
 	wp_enqueue_style( 'bootstrap' );
@@ -42,6 +44,8 @@ function child_scripts_styles() {
 	wp_enqueue_style( 'child-style' );
 	wp_enqueue_script( 'jquery' );
 	wp_enqueue_script( 'bootstrap-js' );
+	wp_enqueue_script( 'moment' );
+	wp_enqueue_script( 'underscore' );
 }
 add_action( 'wp_enqueue_scripts', 'Mitlib\Child\child_scripts_styles' );
 


### PR DESCRIPTION
This seems to resolve date loading on both /docs and /distinctive-collections in the hours multidev environment.

Why are these changes being introduced:

* These are required for some hours related functionality

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/LM-191

How does this address that need:

* registers and enqueues the two libraries

Document any side effects to this change:

* The child theme loads all required libs and does not limit them to pages that need them

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
