### PR TITLE
Removes facebook from social links section of news posts

### DIFF
--- a/web/app/themes/mitlib-news/inc/social.php
+++ b/web/app/themes/mitlib-news/inc/social.php
@@ -22,12 +22,6 @@ namespace Mitlib\News;
 		<span class="si_twitterBlue image_off"></span>
 		</a>
 		</li>
-		<li class="fb soc">
-		<a title="facebook"  href="//libraries.mit.edu/facebook" class="facebookLink">
-		<span class="si_facebook image_on"></span>
-		<span class="si_facebookBlue image_off"></span>
-		 </a>
-		</li>
 		<li class="ig soc">
 		<a title="Instagram"  href="//instagram.com/mitlibraries/">
 		<span class="si_instagram image_on"></span>

--- a/web/app/themes/mitlib-news/style.css
+++ b/web/app/themes/mitlib-news/style.css
@@ -202,11 +202,6 @@ table.hrList tr:nth-child(even) {
 	color: rgb(153,153,153);
 }
 
-.facebookLink {
-	margin-top: 1px;
-	margin-right: 9px;
-}
-
 .no-padding-left {
 	padding-left: 0 !important;
 }
@@ -1468,7 +1463,7 @@ p.search {
 
 
 /*SRPITE*/
-.biblioHeader, .or_cog-25, .or_check-25, .bilbioTechIcon, .or_check-25, .or_star-25, .or_eye-25, .or_life-25, .or_pin-25, .or_sun-25, .or_thumb-25, .si_facebook, .si_facebookBlue, .si_instagram, .si_instagramBlue, .si_twitter, .si_twitterBlue, .info, .update, .searchIcon {
+.biblioHeader, .or_cog-25, .or_check-25, .bilbioTechIcon, .or_check-25, .or_star-25, .or_eye-25, .or_life-25, .or_pin-25, .or_sun-25, .or_thumb-25, .si_instagram, .si_instagramBlue, .si_twitter, .si_twitterBlue, .info, .update, .searchIcon {
 	background: url(images/sprites.png) no-repeat;
 }
 .biblioHeader {
@@ -1521,16 +1516,6 @@ p.search {
 	background-position: -61px -177px;
 	width: 25px;
 	height: 25px;
-}
-.si_facebook {
-	background-position: -161px -27px;
-	width: 26px;
-	height: 24px;
-}
-.si_facebookBlue {
-	background-position: -160px -79px;
-	width: 26px;
-	height: 24px;
 }
 .si_instagram {
 	background-position: -213px -28px;


### PR DESCRIPTION
The image itself is in a sprite and not worth removing, but the styles felt worthwhile to clean up

https://mitlibraries.atlassian.net/browse/LM-348

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
