### PR TITLE
Adds final touches to custom fields across the network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ web/app/plugins/*
 !web/app/plugins/mitlib-post-interviewees
 !web/app/plugins/mitlib-post-interviews
 !web/app/plugins/mitlib-post-locations
+!web/app/plugins/mitlib-post-site-akdc
 !web/app/plugins/mitlib-post-site-news
 !web/app/plugins/mitlib-post-site-parent
 !web/app/plugins/mitlib-post-spotlights

--- a/web/app/mu-plugins/mitlib-post/data/siteakdc/group_56b37a0c995bf.json
+++ b/web/app/mu-plugins/mitlib-post/data/siteakdc/group_56b37a0c995bf.json
@@ -1,0 +1,126 @@
+{
+    "key": "group_56b37a0c995bf",
+    "title": "News and Events",
+    "fields": [
+        {
+            "key": "field_56b37a2079733",
+            "label": "Is this an event?",
+            "name": "is_this_an_event",
+            "type": "true_false",
+            "instructions": "Check this box to display this post as an Event.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_56b37c4779734",
+            "label": "Event Date",
+            "name": "event_date",
+            "type": "date_picker",
+            "instructions": "Select the Event date.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_56b37a2079733",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "display_format": "F j, Y",
+            "return_format": "F j, Y",
+            "first_day": 1
+        },
+        {
+            "key": "field_56b37cbf79735",
+            "label": "Event Start Time",
+            "name": "event_start_time",
+            "type": "text",
+            "instructions": "Enter the event start time. This field is not required.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_56b37a2079733",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "12pm",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": 7,
+            "readonly": 0,
+            "disabled": 0
+        },
+        {
+            "key": "field_56b37d3b79736",
+            "label": "Event End Time",
+            "name": "event_end_time",
+            "type": "text",
+            "instructions": "Enter the event end time. This field is not required.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_56b37a2079733",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "3pm",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": 7,
+            "readonly": 0,
+            "disabled": 0
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "post"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "show_in_rest": false
+}

--- a/web/app/plugins/mitlib-post-site-akdc/README.md
+++ b/web/app/plugins/mitlib-post-site-akdc/README.md
@@ -1,0 +1,7 @@
+# MITlib Post Site - AKDC
+
+This defines a set of custom fields that extend the Post content type for the
+AKDC site.
+
+The fields themselves are defined in a JSON file that can be found in the
+Mitlib Post data folder.

--- a/web/app/plugins/mitlib-post-site-akdc/mitlib-post-site-akdc.php
+++ b/web/app/plugins/mitlib-post-site-akdc/mitlib-post-site-akdc.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Plugin Name: MITlib Post Site (AKDC site)
+ * Description: Extends the built-in content types for the AKDC site
+ * Version: 1.0.0
+ * Author: MIT Libraries
+ * License: GPL2
+ *
+ * @package MITlib Post Site AKDC
+ * @author MIT Libraries
+ */
+
+namespace Mitlib\PostTypes;
+
+// Don't call the file directly!
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Require the necessary classes.
+require_once( plugin_dir_path( __FILE__ ) . 'src/class-siteakdc.php' );
+
+// Register class methods with the WordPress hooks which will call them.
+add_filter( 'acf/settings/load_json', array( 'Mitlib\PostTypes\SiteAkdc', 'load_point' ) );
+add_filter( 'acf/settings/save_json', array( 'Mitlib\PostTypes\SiteAkdc', 'save_point' ) );

--- a/web/app/plugins/mitlib-post-site-akdc/src/class-siteakdc.php
+++ b/web/app/plugins/mitlib-post-site-akdc/src/class-siteakdc.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Class that extends the built-in content types for the AKDC site.
+ *
+ * @package MITlib Post Site AKDC
+ * @since 1.0.0
+ */
+
+namespace Mitlib\PostTypes;
+
+/**
+ * Defines the SiteAkdc class, which is a shell for extending the built-in
+ * content types for use by the AKDC site.
+ */
+class SiteAkdc extends Base {
+
+}


### PR DESCRIPTION
**Why are these changes being introduced:**

The AKDC site on our network has a set of custom fields added to its Post content type, which allow this content type to function as an event.

**Relevant ticket(s):**

https://mitlibraries.atlassian.net/browse/lm-147

**How does this address that need:**

This defines a site-specific extension for the Mitlib Post plugin family, which will be enabled only on the AKDC site. This is the same approach which we've previously adopted for the Parent and News sites when those sites needed to extend the built-in post types.

**Document any side effects to this change:**

This doubles down on using the Post content type for this content, when we might really need to define an Events post type - but that will need to be a coordinated change after we launch the rebuilt site.

**Recommended verification for this PR**
* Log into the AKDC site, in the Custom Fields area of the admin dashboard, at `/akdc/wp-admin/edit.php?post_type=acf-field-group`
* Note that the only set of custom fields listed is shown under a "Sync available" tab
* Load the "Add New Post" form at `/akdc/wp-admin/post-new.php` and note that there is a "News and Events" field group visible
* You can also see the these fields used to render existing content by editing an existing post that has event information, like Post 2194: `/akdc/wp-admin/post.php?post=2194&action=edit`

## Developer

### Secrets

- [x] No secrets are affected

### Documentation

- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
