### PR TITLE
Adds full-width CSS body class to all News pages

### DIFF
--- a/web/app/themes/mitlib-news/functions.php
+++ b/web/app/themes/mitlib-news/functions.php
@@ -137,6 +137,12 @@ function expand_category_scope( $request ) {
 }
 add_filter( 'pre_get_posts', 'Mitlib\News\expand_category_scope' );
 
+// Add full-width CSS body class to all news pages
+// https://developer.wordpress.org/reference/hooks/body_class/#user-contributed-notes .
+add_filter( 'body_class', function( $classes ) {
+	return array_merge( $classes, array( 'full-width' ) );
+} );
+
 /**
  * ============================================================================
  * ============================================================================


### PR DESCRIPTION
Why are these changes being introduced:

* bibliotech archive pages were not displaying properly

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/LM-346

How does this address that need:

* Uses the WordPress `add_filter` method to append `full-width` to the body_class array.

Document any side effects to this change:

* This affects all news pages. It is likely we can restrict it to just the page types that the problem was reported on if this causes visual issues elsewhere

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] There are no new secrets

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
