### PR TITLE
Removes AddThis feature from News

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,6 @@
     "vlucas/phpdotenv": "^5.5",
     "wpackagist-plugin/acf-image-crop-add-on": "^1.4",
     "wpackagist-plugin/add-category-to-pages": "^1.2",
-    "wpackagist-plugin/addthis": "^6.2",
     "wpackagist-plugin/akismet": "^5.0",
     "wpackagist-plugin/antivirus": "^1.4",
     "wpackagist-plugin/black-studio-tinymce-widget": "^2.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a14c7fb707bedc2fe333a31a2f0190d",
+    "content-hash": "e3d2bc1e3910478f39e0fb5d118920d2",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -2754,24 +2754,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/add-category-to-pages/"
-        },
-        {
-            "name": "wpackagist-plugin/addthis",
-            "version": "6.2.7",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/addthis/",
-                "reference": "tags/6.2.7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/addthis.6.2.7.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/addthis/"
         },
         {
             "name": "wpackagist-plugin/akismet",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -49,7 +49,6 @@
   <exclude-pattern>web/app/plugins/acf-image-crop-add-on</exclude-pattern>
   <exclude-pattern>web/app/plugins/acf-location-field</exclude-pattern>
   <exclude-pattern>web/app/plugins/add-category-to-pages</exclude-pattern>
-  <exclude-pattern>web/app/plugins/addthis</exclude-pattern>
   <exclude-pattern>web/app/plugins/advanced-custom-fields-pro</exclude-pattern>
   <exclude-pattern>web/app/plugins/advanced-post-types-order</exclude-pattern>
   <exclude-pattern>web/app/plugins/akismet</exclude-pattern>

--- a/web/app/themes/mitlib-news/css/hide-addthis.css
+++ b/web/app/themes/mitlib-news/css/hide-addthis.css
@@ -1,4 +1,0 @@
-#at_widget,
-.metabox-prefs label:nth-child(13) {
-	display: none;
-}

--- a/web/app/themes/mitlib-news/functions.php
+++ b/web/app/themes/mitlib-news/functions.php
@@ -60,11 +60,6 @@ function admin_styles() {
 	wp_register_style( 'custom-admin', get_stylesheet_directory_uri() . '/css/custom-admin.css', array(), $theme_version );
 	wp_enqueue_style( 'custom-admin' );
 
-	// Users who cannot edit theme options (i.e. non-administrators) are not shown the AddThis panel.
-	if ( ! current_user_can( 'edit_theme_options' ) ) {
-		wp_register_style( 'hide-addthis', get_stylesheet_directory_uri() . '/css/hide-addthis.css', array(), $theme_version );
-		wp_enqueue_style( 'hide-addthis' );
-	}
 }
 add_action( 'admin_head', 'Mitlib\News\admin_styles' );
 

--- a/web/app/themes/mitlib-news/single.php
+++ b/web/app/themes/mitlib-news/single.php
@@ -15,8 +15,6 @@ $category = get_the_category();
 	$type;
 ?>
 
-<!-- Go to www.addthis.com/dashboard to customize your tools -->
-<script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=mitlib" async="async"></script>
 <?php get_template_part( 'inc/sub-headerSingle' ); ?>
 <?php
 if ( ( get_post_type( get_the_ID() ) == 'bibliotech' ) || ( cat_is_ancestor_of( 73, $cat ) or is_category( 73 ) ) ) {
@@ -70,8 +68,6 @@ while ( have_posts() ) :
 		</span>
 		<?php endif; ?>
 	  </div> 
-<!-- Go to www.addthis.com/dashboard to customize your tools -->
-<div class="addthis_sharing_toolbox"></div>
 	<div class="clearfix"></div>
 	<!-- .entry-meta --> 
 	</div>


### PR DESCRIPTION
How to see the changes:

There is a multidev (addthis) that this is deployed to. Looking at an individual news item will not display the addthis buttons on that multidev. The same news item viewed in our live tier will have the addthis buttons.

Why are these changes being introduced:

* AddThis was not frequently used
* The plugin we used was under review and hadn't been updated in a long time and was likely not actually supported

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/LM-361

How does this address that need:

* Removes the plugin via composer
* Removes the manual javascript inclusion that loaded AddThis from an external site
* Removes some styles and custom logic on when to apply them

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
