### PR TITLE
Allows contributors to upload media

### DIFF
--- a/web/app/themes/mitlib-news/functions.php
+++ b/web/app/themes/mitlib-news/functions.php
@@ -132,6 +132,17 @@ function expand_category_scope( $request ) {
 }
 add_filter( 'pre_get_posts', 'Mitlib\News\expand_category_scope' );
 
+/**
+ * Allows contributor to upload images
+ */
+function allow_contributor_uploads() {
+	$contributor = get_role( 'contributor' );
+	$contributor->add_cap( 'upload_files' );
+}
+if ( current_user_can( 'contributor' ) && ! current_user_can( 'upload_files' ) ) {
+	add_action( 'admin_init', 'Mitlib\News\allow_contributor_uploads' );
+}
+
 // Add full-width CSS body class to all news pages
 // https://developer.wordpress.org/reference/hooks/body_class/#user-contributed-notes .
 add_filter( 'body_class', function( $classes ) {


### PR DESCRIPTION
Why are these changes being introduced:

* this feature existed in legacy but wasn't working in the rebuilt network

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/LM-350

How does this address that need:

* Re-introduces the function from legacy that provide this functionality https://github.com/MITLibraries/MITLibraries-news/blob/master/functions.php#L239 The only change from legacy was to introduce the namespace.

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
