### PR TITLE
Remove hours from Docs Services location banner

### DIFF
--- a/web/app/themes/mitlib-child/inc/location.php
+++ b/web/app/themes/mitlib-child/inc/location.php
@@ -25,7 +25,3 @@ $map_page = '/locations/#!' . $docs_slug;
 	<?php endif; ?>
 	<a href="<?php echo esc_attr( $map_page ); ?>">Room: <?php echo esc_html( $docs_building ); ?> <i class="icon-arrow-right"></i></a>
 </div>
-<div class="hours-today">
-	<span>Today's Hours: <span data-location-hours="Document Services"></span></span>  | 
-	<a href="/hours" class="link-hours-all">See all hours</a>
-</div>


### PR DESCRIPTION
https://mitlibraries.atlassian.net/browse/LM-365

Context: Hours will be moved to the sidebar by enabling the pull hours plugin and then using a widget provided by that plugin. This just removes the newly redundant hours in the title banner.

## Developer

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
