### PR TITLE
Changes ACF to native composer install

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -237,9 +237,9 @@ Please see the readme for that project for [installation](https://github.com/pan
 
 #### Required build secrets
 
-- `ACF_PRO_KEY` - License key necessary for installing the Advanced Custom Fields Pro plugin
-- `github-oauth.github.com` - User access token defined by the `mitlib-wp-network-deploy` account
-
+* `COMPOSER_AUTH` - License key necessary for installing the Advanced Custom Fields Pro plugin. Content can be found in
+  the official acf documentation `auth.json` file and just removing all the line breaks
+* `github-oauth.github.com` - User access token defined by the `mitlib-wp-network-deploy` account
 
 ### Application secrets
 
@@ -278,12 +278,11 @@ Bedrock makes use of an `.env` file to store environment variables. Pantheon tak
 - `WP_ENV` - Set to environment (`development`, `staging`, `production`)
 - `WP_HOME` - Full URL to WordPress home (https://example.com)
 - `WP_SITEURL` - Full URL to WordPress including subdirectory (https://example.com/wp)
-- `ACF_PRO_KEY` - License key necessary for installing the Advanced Custom Fields Pro plugin
 - `AUTH_KEY`, `SECURE_AUTH_KEY`, `LOGGED_IN_KEY`, `NONCE_KEY`, `AUTH_SALT`, `SECURE_AUTH_SALT`, `LOGGED_IN_SALT`, `NONCE_SALT`
   - Generate with [wp-cli-dotenv-command](https://github.com/aaemnnosttv/wp-cli-dotenv-command)
   - Regenerate with [Bedrock's WordPress salts generator](https://roots.io/salts.html)
-- `COMPOSER_AUTH` - The user access token defined by the `mitlib-wp-network-deploy` account, for installing forked
-  plugins
+- `COMPOSER_AUTH` A JSON formatted object that has one entry for the user access token defined by the `mitlib-wp-network-deploy` account, for installing forked plugins and an entry for our Advanced Custom Fields Pro authentication. [see Shared-Prod-Pantheon folder in lastpass for values and additional context for `auth.json` and `COMPOSER_AUTH`] [NOTE: composer does not read from .env so locally these also need to be in auth.json and kept out of version control]
+  * composer will read an auth.json file in a user home directory or the root directory of the application. If using the application root, please ensure it is gitignored. Our lastpass should contain a current working version of what to put in auth.json (and if you make changes to auth.json locally, consisider whether they should also change in lastpass or in the CI and Pantheon equivalent which is `COMPOSER_AUTH`!)
 
 ### Github secrets
 
@@ -291,13 +290,10 @@ Managed with: Github web UI
 
 In addition to secret values stored using Terminus, we also define certain values used by our CI workflow using Github secrets.
 
-- `ACF_PRO_KEY` License key necessary for installing the Advanced Custom Fields Pro plugin.
-- `COMPOSER_AUTH` The user access token defined by the `mitlib-wp-network-deploy` account, for installing forked plugins.
+- `COMPOSER_AUTH` A JSON structure that has one entry for the user access token defined by the `mitlib-wp-network-deploy` account, for installing forked plugins and an entry for our Advanced Custom Fields Pro authentication. [see lastpass]
 - `DEPLOY_SSH_KNOWN_HOSTS` The known_hosts file to allow GitHubs' CI to trust the Pantheon git server.
 - `DEPLOY_SSH_PRIVATE_KEY` The private key (with blank passphrase) used to connect to Pantheon's git server. The public key is added to your personal settings within Pantheon.
 - `PANTHEON_REPOSITORY` The SSH-format address of the git repository in Pantheon.
-
-
 
 ---
 **The sections below were included in the original Readme, and I'm not sure whether they are still useful in this context.**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       run: composer install --no-progress --prefer-dist --optimize-autoloader
       env:
         ACF_PRO_KEY: ${{ secrets.ACF_PRO_KEY }}
-        COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{secrets.COMPOSER_AUTH}}"} }'
+        COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
 
     - name: Run tests
       run: composer security

--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,4 @@ Thumbs.db
 # MISC #
 ##########
 .vscode
+auth.json

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     },
     {
       "type": "composer",
-      "url": "https://pivvenit.github.io/acf-composer-bridge/composer/v3/wordpress-plugin/"
+      "url": "https://connect.advancedcustomfields.com"
     },
     {
       "type": "vcs",
@@ -88,7 +88,7 @@
   ],
   "require": {
     "php": ">=7.4",
-    "advanced-custom-fields/advanced-custom-fields-pro": "^5",
+    "wpengine/advanced-custom-fields-pro": "^5",
     "composer/installers": "^2.2",
     "connectthink/wp-scss": "^2.4@beta",
     "google/apiclient": "^2.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6aa8482cc37f5a43988a1af338fab523",
+    "content-hash": "37231fafb14b6a104b7fcb007a11ed01",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -30,40 +30,6 @@
                 "source": "https://github.com/matt-bernhardt/WP-SCSS/tree/2.4.1-beta2"
             },
             "time": "2022-10-18T23:27:41+00:00"
-        },
-        {
-            "name": "advanced-custom-fields/advanced-custom-fields-pro",
-            "version": "5.12.4",
-            "dist": {
-                "type": "zip",
-                "url": "https://connect.advancedcustomfields.com/v2/plugins/download?p=pro&t=5.12.4"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0",
-                "pivvenit/acf-pro-installer": "^2.4.0 || ^3.0"
-            },
-            "type": "wordpress-plugin",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Elliot Condon",
-                    "homepage": "http://www.elliotcondon.com",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "PivvenIT",
-                    "homepage": "https://pivvenit.nl",
-                    "role": "Composer Repository maintainer"
-                }
-            ],
-            "description": "Advanced Custom Fields PRO",
-            "homepage": "https://www.advancedcustomfields.com/",
-            "support": {
-                "docs": "https://www.advancedcustomfields.com/resources/",
-                "forum": "https://support.advancedcustomfields.com/topics/"
-            }
         },
         {
             "name": "composer/installers",
@@ -1428,74 +1394,6 @@
                 }
             ],
             "time": "2023-03-05T17:13:09+00:00"
-        },
-        {
-            "name": "pivvenit/acf-pro-installer",
-            "version": "3.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pivvenit/acf-pro-installer.git",
-                "reference": "e14e56c23f5596573c01dd87edd4ca890ef2a56a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pivvenit/acf-pro-installer/zipball/e14e56c23f5596573c01dd87edd4ca890ef2a56a",
-                "reference": "e14e56c23f5596573c01dd87edd4ca890ef2a56a",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1||^2.0",
-                "ext-json": "*",
-                "php": "^7.3||^8.0",
-                "vlucas/phpdotenv": "^2.0 || ^3.0 || ^4.0 || ^5.0"
-            },
-            "replace": {
-                "philippbaschke/acf-pro-installer": "1.0.2"
-            },
-            "require-dev": {
-                "composer/composer": "^1.0|| ^2.0",
-                "php-parallel-lint/php-parallel-lint": "^1.2.0",
-                "phpstan/phpstan": "^1.1.2",
-                "phpunit/phpunit": "^9.0",
-                "rregeer/phpunit-coverage-check": "^0.3.1",
-                "squizlabs/php_codesniffer": "^3.4",
-                "symfony/process": "^5.1"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PivvenIT\\Composer\\Installers\\ACFPro\\ACFProInstallerPlugin",
-                "plugin-modifies-downloads": true
-            },
-            "autoload": {
-                "psr-4": {
-                    "PivvenIT\\Composer\\Installers\\ACFPro\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PivvenIT",
-                    "homepage": "https://pivvenit.nl"
-                }
-            ],
-            "description": "A modern maintained install helper for Advanced Custom Fields PRO",
-            "keywords": [
-                "acf",
-                "composer",
-                "env",
-                "plugin",
-                "pro",
-                "wordpress",
-                "wp"
-            ],
-            "support": {
-                "issues": "https://github.com/pivvenit/acf-pro-installer/issues",
-                "source": "https://github.com/pivvenit/acf-pro-installer/tree/3.2.0"
-            },
-            "time": "2022-08-26T07:12:57+00:00"
         },
         {
             "name": "psr/cache",
@@ -3318,6 +3216,21 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wpcf7-recaptcha/"
+        },
+        {
+            "name": "wpengine/advanced-custom-fields-pro",
+            "version": "5.12.6",
+            "dist": {
+                "type": "zip",
+                "url": "https://connect.advancedcustomfields.com/v2/plugins/composer_download?p=pro&t=5.12.6"
+            },
+            "require": {
+                "composer/installers": "~1.0 || ~2.0"
+            },
+            "replace": {
+                "wpackagist-plugin/advanced-custom-fields": "self.version"
+            },
+            "type": "wordpress-plugin"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
NOTE: terminus secret `ACF_PRO_KEY` should be removed only after _all_ environments have been updated with this change. It will cause no harm to keep it there, but it will not actually do anything once these changes land and should be removed.

Why are these changes being introduced:

* ACF now allows direct install and the shim we used is being retired

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/LM-236

How does this address that need:

* Removes acf-composer-bridge repository
* Adds acf native repository

Document any side effects to this change:

`COMPOSER_AUTH` env is required in local .env as well as being set via terminus secret plugin.

## Developer

### Secrets

- [x] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [x] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated (updated to new version of ACF during this process to address security concern)


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
