### PR TITLE
Fix reference to calendar icon

### DIFF
--- a/web/app/themes/mitlib-parent/lib/news.php
+++ b/web/app/themes/mitlib-parent/lib/news.php
@@ -193,7 +193,7 @@ function RenderPool( $items ) {
 		if ( $item->post_type === 'post' && array_key_exists( 'is_event', $custom ) ) {
 			if ( $custom['is_event'][0] === '1' ) {
 				$eventDate = \DateTime::createFromFormat( 'Ymd', $custom['event_date'][0] );
-				$eventDate = '<div class="date-event"><img alt="calendar icon" src="/wp-content/themes/libraries/images/calendar.svg" width="13px" height="13px" ><span class="event">' . date_format( $eventDate, 'F j' ) . '</span>';
+				$eventDate = '<div class="date-event"><img alt="calendar icon" src="' . esc_url( get_template_directory_uri() . '/images/calendar.svg' ) . '" width="13px" height="13px" ><span class="event">' . date_format( $eventDate, 'F j' ) . '</span>';
 				if ( $custom['event_start_time'][0] != '' ) {
 					$eventDate = $eventDate . '<span class="time-event"> ' . $custom['event_start_time'][0];
 				};


### PR DESCRIPTION
** Why are these changes being introduced:

* The code for rendering news stories on the network homepage includes a reference to an outdated file path.

** Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-431

** How does this address that need:

* This replaces the outdated file path with a technique that is both not broken and more functional, relying on get_template_directory_uri() to get the correct path. This is the same technique we use in the opengraph partial (for the network graphic) and in functions.php for loading lots of theme assets.

** Document any side effects to this change:

* There should be none. I'm choosing not to consider for now any other options, including refactoring the event date handling in general (lines 192 - 208 in this file) or converting this image to one loaded by CSS.

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are modified

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
