### PR TITLE
Catch up to child theme style changes

### DIFF
--- a/web/app/themes/mitlib-child/style.css
+++ b/web/app/themes/mitlib-child/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib Child
 Author: MIT Libraries
-Version: 0.1.1
+Version: 1.0.0
 Description: A child theme of the MIT Libraries' parent, focused on sites built primarily with static pages.
 Template: mitlib-parent
 

--- a/web/app/themes/mitlib-child/style.css
+++ b/web/app/themes/mitlib-child/style.css
@@ -1108,8 +1108,6 @@ a.px14 {
 	font-weight: 600;
 	margin-left: 65px;
 	font-size: 16px;
-	position: relative;
-	top: 5px;
 }
 
 .category-image {

--- a/web/app/themes/mitlib-child/style.css
+++ b/web/app/themes/mitlib-child/style.css
@@ -960,10 +960,8 @@ footer .footerHeader {
 	clear: both;
 }
 
-.childTheme .staff-widget {
-	float: left;
-	width: 30%;
-	margin-right: 5%;
+.staff-widget {
+	margin-top: 1em;
 }
 
 .entry-content .staff-widget .textwidget,
@@ -1299,6 +1297,11 @@ a.px14 {
 		width: 100%;
 		margin-bottom: 50px;
 		float: none;
+	}
+
+	.childTheme .has-sidebar .sidebar {
+		clear: both;
+		padding-top: 50px;
 	}
 
 	ul.nav li.dropdown:hover > ul.dropdown-menu {


### PR DESCRIPTION
This repeats two changes from the legacy child theme that were somehow omitted when we built out the new child theme.

The first commit here repeats https://github.com/MITLibraries/MITLibraries-child/commit/f06d083b09f95f0315a24ff17de2884897b1ae2b , which adjusts how widgets with the "staff widget" class are displayed

The second commit repeats https://github.com/MITLibraries/MITLibraries-child/commit/de028efe1ffbbcb2503eddfbdab64a9346fb6080 , which tweaks - slightly - the display of the location name above an Exhibit record.

There are URLs to show the changes on the linked Jira ticket:
https://mitlibraries.atlassian.net/browse/LM-437

## Developer

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
