### PR TITLE
Clean up image and single partials in Parent and Child themes

### DIFF
--- a/web/app/themes/mitlib-child/image.php
+++ b/web/app/themes/mitlib-child/image.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * The template for displaying image attachments.
+ *
+ * Learn more: http://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package MITlib_Parent
+ * @since 0.2.0
+ */
+
+namespace Mitlib\Parent;
+
+get_header(); ?>
+		<?php get_template_part( 'inc/breadcrumbs' ); ?>
+
+		<div id="stage" class="inner" role="main">
+			
+			<div id="content" class="content has-sidebar">
+				
+				<div class="main-content content-main">
+
+		<?php
+		while ( have_posts() ) :
+			the_post();
+			?>
+
+				<article id="post-<?php the_ID(); ?>" <?php post_class( 'image-attachment' ); ?>>
+					<header class="entry-header">
+						<h1 class="entry-title"><?php the_title(); ?></h1>
+
+						<footer class="entry-meta">
+							<?php
+								$metadata = wp_get_attachment_metadata();
+								printf(
+									'<span class="meta-prep meta-prep-entry-date">Published </span> <span class="entry-date"><time class="entry-date" datetime="%1$s">%2$s</time></span> at <a href="%3$s" title="Link to full-size image">%4$s &times; %5$s</a> in <a href="%6$s" title="Return to %7$s" rel="gallery">%8$s</a>.',
+									esc_attr( get_the_date( 'c' ) ),
+									esc_html( get_the_date() ),
+									esc_url( wp_get_attachment_url() ),
+									esc_html( $metadata['width'] ),
+									esc_html( $metadata['height'] ),
+									esc_url( get_permalink( $post->post_parent ) ),
+									esc_attr( strip_tags( get_the_title( $post->post_parent ) ) ),
+									esc_html( get_the_title( $post->post_parent ) )
+								);
+							?>
+							<?php edit_post_link( __( 'Edit', 'twentytwelve' ), '<span class="edit-link">', '</span>' ); ?>
+						</footer><!-- .entry-meta -->
+
+						<nav id="image-navigation" class="image-navigation" role="navigation">
+							<span class="previous-image"><?php previous_image_link( false, __( '&larr; Previous', 'twentytwelve' ) ); ?></span>
+							<span class="next-image"><?php next_image_link( false, __( 'Next &rarr;', 'twentytwelve' ) ); ?></span>
+						</nav><!-- #image-navigation -->
+					</header><!-- .entry-header -->
+
+					<div class="entry-content">
+
+						<div class="entry-attachment">
+							<div class="attachment">
+			<?php
+			/**
+			 * Grab the IDs of all the image attachments in a gallery so we can get the URL of the next adjacent image in a gallery,
+			 * or the first image (if we're looking at the last image in a gallery), or, in a gallery of one, just the link to that image file
+			 */
+			$attachments = array_values(
+				get_children(
+					array(
+						'post_parent' => $post->post_parent,
+						'post_status' => 'inherit',
+						'post_type' => 'attachment',
+						'post_mime_type' => 'image',
+						'order' => 'ASC',
+						'orderby' => 'menu_order ID',
+					)
+				)
+			);
+			foreach ( $attachments as $k => $attachment ) :
+				if ( $attachment->ID == $post->ID ) {
+					break; }
+endforeach;
+
+			$k++;
+			// If there is more than 1 attachment in a gallery...
+			if ( count( $attachments ) > 1 ) :
+				if ( isset( $attachments[ $k ] ) ) :
+					// Get the URL of the next image attachment...
+					$next_attachment_url = get_attachment_link( $attachments[ $k ]->ID );
+				else :
+					// Or get the URL of the first image attachment...
+					$next_attachment_url = get_attachment_link( $attachments[0]->ID );
+				endif;
+else :
+	// Or, if there's only 1 image, get the URL of the image.
+	$next_attachment_url = wp_get_attachment_url();
+endif;
+?>
+								<a href="<?php echo esc_url( $next_attachment_url ); ?>" title="<?php the_title_attribute(); ?>" rel="attachment">
+													<?php
+													$attachment_size = apply_filters( 'twentytwelve_attachment_size', array( 960, 960 ) );
+													echo wp_get_attachment_image( $post->ID, $attachment_size );
+													?>
+								</a>
+
+								<?php if ( ! empty( $post->post_excerpt ) ) : ?>
+								<div class="entry-caption">
+									<?php the_excerpt(); ?>
+								</div>
+								<?php endif; ?>
+							</div><!-- .attachment -->
+
+						</div><!-- .entry-attachment -->
+
+						<div class="entry-description">
+							<?php the_content(); ?>
+							<?php
+							wp_link_pages(
+								array(
+									'before' => '<div class="page-links">' . __( 'Pages:', 'twentytwelve' ),
+									'after' => '</div>',
+								)
+							);
+							?>
+						</div><!-- .entry-description -->
+
+					</div><!-- .entry-content -->
+
+				</article><!-- #post -->
+
+				<?php comments_template(); ?>
+
+			<?php endwhile; // end of the loop. ?>
+				
+			</div><!-- .main-content -->
+				
+			<?php get_sidebar(); ?>
+			
+		</div><!-- #content -->
+	</div><!-- #primary -->
+
+<?php get_footer(); ?>

--- a/web/app/themes/mitlib-child/image.php
+++ b/web/app/themes/mitlib-child/image.php
@@ -4,17 +4,19 @@
  *
  * Learn more: http://codex.wordpress.org/Template_Hierarchy
  *
- * @package MITlib_Parent
- * @since 0.2.0
+ * @package MITlib_Child
+ * @since 1.0.0
  */
 
-namespace Mitlib\Parent;
+namespace Mitlib\Child;
 
 get_header(); ?>
 		<?php get_template_part( 'inc/breadcrumbs' ); ?>
 
 		<div id="stage" class="inner" role="main">
 			
+			<?php get_template_part( 'inc/title-banner' ); ?>
+
 			<div id="content" class="content has-sidebar">
 				
 				<div class="main-content content-main">

--- a/web/app/themes/mitlib-parent/image.php
+++ b/web/app/themes/mitlib-parent/image.php
@@ -15,8 +15,6 @@ get_header(); ?>
 
 		<div id="stage" class="inner" role="main">
 			
-		<?php get_template_part( 'inc/postHead' ); ?>
-
 			<div id="content" class="content has-sidebar">
 				
 				<div class="main-content content-main">

--- a/web/app/themes/mitlib-parent/single.php
+++ b/web/app/themes/mitlib-parent/single.php
@@ -15,8 +15,6 @@ get_header(); ?>
 	
 <div id="stage" class="inner" role="main">
 
-	<?php get_template_part( 'inc/postHead' ); ?>
-			
 		<div id="content" class="content has-sidebar">
 
 				<div class="content-main main-content">			


### PR DESCRIPTION
This removes invalid references in some templates in the parent theme, and creates forks in the child theme with updated references to what the partials are now.

Ticket: https://mitlibraries.atlassian.net/browse/LM-438

## Developer

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected by this change

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
