### PR TITLE
Add hours loader to additional locations

### DIFF
--- a/docs/reference/library-hours.md
+++ b/docs/reference/library-hours.md
@@ -1,0 +1,50 @@
+# How we manage and load library hours
+
+This page will describe how we manage library hours - across multiple locations,
+on multiple pages, and over timeframes that accommodate both an underlying
+standard calendar as well as during exceptional circumstances (which may last
+from a few hours to several days).
+
+## Summary
+
+* The UX staff manages a Google spreadsheet with multiple data sheets.
+* Library staff who manage a library location then maintain, along with UX
+  staff, the contents of those data sheets.
+* This WordPress application provides a plugin, `MITlib Pull Hours`, which is
+  capable of harvesting the contents of that spreadsheet into a set of JSON
+  documents on the webserver.
+* The plugin also provides a javascript library, `hours-loader.js`, which looks
+  for data attributes in the client-facing markup which indicate that library
+  hours need to be displayed. The hours loader compares the contents of the
+  various JSON documents, determines the relevant hours information, and places
+  that information into the DOM.
+* The hours loader can be enqueued either via widgets provided by the plugin,
+  or by templates provided by the theme. These widgets and templates include the
+  data attributes necessary for the hours loader to function.
+
+## Technical requirements for displaying hours in a location
+
+In order for library hours to be displayed on a page, two things must be true:
+
+1. The page must load `hours-loader.js`.
+2. The element on the page which will contain the hours must have the necessary
+   data attribute and values attached to it. There are two ways to satisfy this
+   condition:
+   a. For most uses, the element must have an attribute of
+      `data-location-hours`, with a value that exactly matches the location to
+      be displayed (as recorded in the Google spreadsheet).
+   b. The only exception to the above is the main grid of hours, which is also
+      the only way to display hours for a date other than today. For the hours
+      grid, there must be a table with the class `hrList`, with data attributes
+      of `data-location` assigned to each row and `data-day` assigned to each
+      cell that shows hours. The `data-location` value must match the name of a
+      location, while `data-day` should be the integer value for the day of the
+      week being displayed (the week itself is loaded from the querystring of
+      the page).
+
+## References
+
+* [UX wiki documentation](https://wikis.mit.edu/confluence/display/UXWS/Hours)
+* [MITlib Pull Hours plugin](https://github.com/MITLibraries/mitlib-wp-network/tree/master/web/app/plugins/mitlib-pull-hours)
+* [Parent theme hours template](https://github.com/MITLibraries/mitlib-wp-network/blob/master/web/app/themes/mitlib-parent/templates/page-hours.php)
+* [Parent theme study spaces template](https://github.com/MITLibraries/mitlib-wp-network/blob/master/web/app/themes/mitlib-parent/templates/page-study-spaces.php)

--- a/web/app/themes/mitlib-parent/functions.php
+++ b/web/app/themes/mitlib-parent/functions.php
@@ -182,8 +182,8 @@ function setup_scripts_styles() {
 	wp_register_script( 'hours-stickyMenu', get_template_directory_uri() . '/js/sticky-hours.menu.js', array( 'jquery-sticky' ), $theme_version, true );
 	wp_register_script( 'moment', get_template_directory_uri() . '/js/libs/moment.min.js', array(), $theme_version, true );
 	wp_register_script( 'underscore', get_template_directory_uri() . '/js/libs/underscore.min.js', array(), $theme_version, true );
-	wp_register_script( 'hours-loader', get_template_directory_uri() . '../../../plugins/mitlib-pull-hours/js/hours-loader.js', array(), $theme_version, true );
-	wp_register_script( 'parent-hours', get_template_directory_uri() . '/js/make.datepicker.js', array( 'jquery', 'gldatepickerJS', 'hours-scrollStick', 'hours-stickyMenu', 'underscore', 'moment', 'hours-loader' ), $theme_version, true );
+	wp_register_script( 'hours-loader-theme', get_template_directory_uri() . '../../../plugins/mitlib-pull-hours/js/hours-loader.js', array(), $theme_version, true );
+	wp_register_script( 'parent-hours', get_template_directory_uri() . '/js/make.datepicker.js', array( 'jquery', 'gldatepickerJS', 'hours-scrollStick', 'hours-stickyMenu', 'underscore', 'moment', 'hours-loader-theme' ), $theme_version, true );
 
 	// Search bundle.
 	wp_register_script( 'search-ie', get_template_directory_uri() . '/js/search-ie.js', array(), $theme_version, false );
@@ -234,12 +234,16 @@ function setup_scripts_styles() {
 		wp_enqueue_script( 'formsJS' );
 	}
 
+	// While some parts of the site load hours via widgets (which enqueue the
+	// hours loader and its dependencies on their own), other parts of the site
+	// load hours via templates. For the templates, we enqueue the hours loader
+	// via these conditionals.
 	if ( is_page( 'hours' ) ) {
-		wp_enqueue_style( 'parent-hours' );
+		wp_enqueue_style( 'parent-hours' ); // This hours styles are focused on the datepicker, which is specific to this one page.
 		wp_enqueue_script( 'parent-hours' );
 	}
 
-	if ( is_page_template( 'templates/page-location-2021.php' ) || is_page_template( 'templates/page-location.php' ) ) {
+	if ( is_page_template( 'templates/page-location-2021.php' ) || is_page_template( 'templates/page-location.php' ) || is_page_template( 'templates/page-study-spaces.php' ) ) {
 		wp_enqueue_script( 'parent-hours' );
 	}
 


### PR DESCRIPTION
### Why are these changes being introduced:

* A few places around the site are not loading hours when they should.
  Affected pages include the Study Spaces page, as well as two pages
  that load the slim widget in a sidebar (Data Services and the GIS
  lab).

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-445

### How does this address that need:

* The problem with the sidebar turns out to be that we've used the
  name 'hours-loader' in both the hours plugin and in the parent
  theme - so when the slim widget tries to enqueue the hours loader,
  its definition is getting stomped by the theme's version - which
  doesn't have the same dependencies (the theme assigns dependencies
  in a different order, and also references the loader script via a
  different technique).

  The change in dependency structure means that the widget was
  loading the hours loader, but not the underscore dependency - so
  we were seeing "underscore not defined" errors in the console.

  This change tweaks the name used by the theme for this script, so
  that name collisions don't happen. You can confirm this change's
  effect by looking at the version strings used. The plugin assigns a
  version of 1.10.0 at the moment, while the theme assigns the theme
  version (0.2.1). You can also see the name via the "id" parameter
  of the script tag.

* The problem with the study spaces page turns out to be that it just
  didn't load the hours loader at all. We resolve this by adding the
  study spaces template to the conditional check for when to enqueue
  the hours loader.

* This also adds some code comments to try and describe how all this
  works a little better. It isn't what is needed ultimately, but it
  should serve as a reminder to future-us about what is happening.

### Document any side effects to this change:

* There is a lot of code smell hanging around how we implement the
  hours loader right now. Sometimes the loader gets brought along
  by the page slug ("/hours"), sometimes because of the page template
  being loaded (location, location-2021, or study-spaces), and yet
  other times because a widget is placed on the page.

  This change extends that smell, but does not introduce any
  fundamentally new approaches. My desired end state is to register
  and enqueue the hours loader (and its dependencies) via the plugin
  only - but that will require some fine-tuning of this approach
  because of how we use two templates (study spaces and the hours
  grid) that in turn rely on the location post type (provided by a
  different set of plugins).

  For now, though, this solves the immediate problem.

* One intentional side effect of this change is to introduce a reference
  page in the documentation that describes the hours system as a
  whole (see the second commit).

## Developer

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected by this change.

### Documentation

- [x] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
