### PR TITLE
Re-introduce wp_title implementation

### DIFF
--- a/web/app/themes/mitlib-parent/functions.php
+++ b/web/app/themes/mitlib-parent/functions.php
@@ -259,6 +259,38 @@ function setup_scripts_styles() {
 add_action( 'wp_enqueue_scripts', 'Mitlib\Parent\setup_scripts_styles' );
 
 /**
+ * Creates a nicely formatted and more specific title element text
+ * for output in head of document, based on current view.
+ *
+ * @param string $title Default title text for current view.
+ * @param string $sep Optional separator.
+ * @return string Filtered title.
+ */
+function customize_title( $title, $sep ) {
+	global $paged, $page;
+
+	if ( is_feed() ) {
+		return $title; }
+
+	// Add the site name.
+	$title .= get_bloginfo( 'name' );
+
+	// Add the site description for the home/front page.
+	$site_description = get_bloginfo( 'description', 'display' );
+	if ( $site_description && ( is_home() || is_front_page() ) ) {
+		$title = "$title $sep $site_description";
+	}
+
+	// Add a page number if necessary.
+	if ( $paged >= 2 || $page >= 2 ) {
+		$title = "$title $sep " . sprintf( 'Page %s', max( $paged, $page ) );
+	}
+
+	return $title;
+}
+add_filter( 'wp_title', 'Mitlib\Parent\customize_title', 10, 2 );
+
+/**
  * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
  */
 function customize_preview_js() {


### PR DESCRIPTION
### Why are these changes being introduced:

The legacy parent theme had this function in place, which didn't seem necessary as `wp_title` is provided by WordPress already. However, it doesn't seem that the documentation for `wp_title` is accurate - and this function is actually needed.

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/lm-444

### How does this address that need:

This re-introduces the customization function from the legacy theme.

### Document any side effects to this change:

None - although this function shouldn't be necessary - yet it is.

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected by this change

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
