### PR TITLE
Prepend domains in Matomo tracking code

### DIFF
--- a/web/app/plugins/mitlib-analytics/mitlib-analytics.php
+++ b/web/app/plugins/mitlib-analytics/mitlib-analytics.php
@@ -185,6 +185,7 @@ function mitlib_analytics_view() {
   <script>
     var _paq = window._paq = window._paq || [];
     /* tracker methods like 'setCustomDimension' should be called before 'trackPageView' */
+    _paq.push(['setDocumentTitle', document.domain + '/'' + document.title]);
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {


### PR DESCRIPTION
### Why these changes are being introduced:

The Page report in Matomo needs to show the full domain name for each tracked page,

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/UXWS-1564

### How this addresses that need:

This prepends the site domains to each view to provide the complete URL, [as described here.](https://forum.matomo.org/t/complete-url-in-pages-report/48187/2)

### Side effects of this change:

This change has already been made in LibGuides.

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
