### PR TITLE
Standardize how location alerts are handled

### DIFF
--- a/web/app/mu-plugins/mitlib-post/data/location/group_58e22931ab9f5.json
+++ b/web/app/mu-plugins/mitlib-post/data/location/group_58e22931ab9f5.json
@@ -7,7 +7,7 @@
             "label": "Alert Title",
             "name": "alert_title",
             "type": "wysiwyg",
-            "instructions": "This field must contain content for the alert to work. Also, don't add any HTML tags.",
+            "instructions": "This field must contain content for the alert to work. This content is automatically wrapped in an h3 or div tag depending on location. Do not add HTML tags here.",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {
@@ -26,7 +26,7 @@
             "label": "Alert Content",
             "name": "alert_content",
             "type": "wysiwyg",
-            "instructions": "This field must contain content for the alert to work. Also, don't add any HTML tags.",
+            "instructions": "This field must contain content for the alert to work. The only supported HTML tags are links, bold, and italics (a, em, and strong).",
             "required": 0,
             "conditional_logic": 0,
             "wrapper": {

--- a/web/app/themes/mitlib-parent/inc/content-location-2021.php
+++ b/web/app/themes/mitlib-parent/inc/content-location-2021.php
@@ -66,16 +66,22 @@ if ( 0 >= $subs ) {
 	$strLocation = 'noThumbs';
 }
 
-$alertTitle   = cf( 'alert_title' );
-$alertContent = cf( 'alert_content' );
+$alert_title   = cf( 'alert_title' );
+$alert_content = cf( 'alert_content' );
 ?>
 
 <div class="libraryAlertTop">
 	<?php
-	if ( 0 == $showAlert && '' !== $alertTitle ) {
-		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- alertContent comes from a rich text field, and needs careful treatment. Probably wp_kses and negotiations with site builders.
-		echo '<div class="libraryAlert">' . '<div class="location--alerts flex-container"><i class="icon-exclamation-sign"></i>' . '<div class="alertText">' . '<h3>' . esc_html( $alertTitle ) . '</h3>' . '<p>' . $alertContent . '</p>' . '</div>' . '</div>' . '</div>';
-		// phpcs:enable
+	if ( 0 == $showAlert && '' !== $alert_title ) {
+		$no_html = array();
+		$allowed_html = array(
+			'a' => array(
+				'href' => array(),
+			),
+			'em' => array(),
+			'strong' => array(),
+		);
+		echo '<div class="libraryAlert">' . '<div class="location--alerts flex-container"><i class="icon-exclamation-sign"></i>' . '<div class="alertText">' . '<h3>' . wp_kses( $alert_title, $no_html ) . '</h3>' . '<p>' . wp_kses( $alert_content, $allowed_html ) . '</p>' . '</div>' . '</div>' . '</div>';
 	}
 	?>
 </div>				

--- a/web/app/themes/mitlib-parent/inc/content-location-2021.php
+++ b/web/app/themes/mitlib-parent/inc/content-location-2021.php
@@ -67,21 +67,12 @@ if ( 0 >= $subs ) {
 }
 
 $alert_title   = cf( 'alert_title' );
-$alert_content = cf( 'alert_content' );
 ?>
 
 <div class="libraryAlertTop">
 	<?php
 	if ( 0 == $showAlert && '' !== $alert_title ) {
-		$no_html = array();
-		$allowed_html = array(
-			'a' => array(
-				'href' => array(),
-			),
-			'em' => array(),
-			'strong' => array(),
-		);
-		echo '<div class="libraryAlert">' . '<div class="location--alerts flex-container"><i class="icon-exclamation-sign"></i>' . '<div class="alertText">' . '<h3>' . wp_kses( $alert_title, $no_html ) . '</h3>' . '<p>' . wp_kses( $alert_content, $allowed_html ) . '</p>' . '</div>' . '</div>' . '</div>';
+		get_template_part( 'inc/location', 'alert' );
 	}
 	?>
 </div>				

--- a/web/app/themes/mitlib-parent/inc/content-location.php
+++ b/web/app/themes/mitlib-parent/inc/content-location.php
@@ -90,23 +90,14 @@ if ( $subs <= 0 ) {
 
 
 $alert_title = cf( 'alert_title' );
-$alert_content = cf( 'alert_content' );
 ?>
 
 <div class="libraryAlertTop">
-<?php
-if ( 0 == $showAlert && '' !== $alert_title ) {
-	$no_html = array();
-	$allowed_html = array(
-		'a' => array(
-			'href' => array(),
-		),
-		'em' => array(),
-		'strong' => array(),
-	);
-	echo '<div class="libraryAlert">' . '<div class="location--alerts flex-container"><i class="icon-exclamation-sign"></i>' . '<div class="alertText">' . '<h3>' . wp_kses( $alert_title, $no_html ) . '</h3>' . '<p>' . wp_kses( $alert_content, $allowed_html ) . '</p>' . '</div>' . '</div>' . '</div>';
-}
-?>
+	<?php
+	if ( 0 == $showAlert && '' !== $alert_title ) {
+		get_template_part( 'inc/location', 'alert' );
+	}
+	?>
 </div>				
 	<div class="title-page libraryTitle flex-container">
 		

--- a/web/app/themes/mitlib-parent/inc/content-location.php
+++ b/web/app/themes/mitlib-parent/inc/content-location.php
@@ -89,16 +89,22 @@ if ( $subs <= 0 ) {
 }
 
 
-	$alertTitle = cf( 'alert_title' );
-	$alertContent = cf( 'alert_content' );
+$alert_title = cf( 'alert_title' );
+$alert_content = cf( 'alert_content' );
 ?>
 
 <div class="libraryAlertTop">
 <?php
-if ( $showAlert == 0 && $alertTitle != '' ) {
-	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- alertContent comes from a rich text field, and needs careful treatment. Probably wp_kses and negotiations with site builders.
-	echo '<div class="libraryAlert">' . '<div class="location--alerts flex-container"><i class="icon-exclamation-sign"></i>' . '<div class="alertText">' . '<h3>' . esc_html( $alertTitle ) . '</h3>' . '<p>' . $alertContent . '</p>' . '</div>' . '</div>' . '</div>';
-	// phpcs:enable
+if ( 0 == $showAlert && '' !== $alert_title ) {
+	$no_html = array();
+	$allowed_html = array(
+		'a' => array(
+			'href' => array(),
+		),
+		'em' => array(),
+		'strong' => array(),
+	);
+	echo '<div class="libraryAlert">' . '<div class="location--alerts flex-container"><i class="icon-exclamation-sign"></i>' . '<div class="alertText">' . '<h3>' . wp_kses( $alert_title, $no_html ) . '</h3>' . '<p>' . wp_kses( $alert_content, $allowed_html ) . '</p>' . '</div>' . '</div>' . '</div>';
 }
 ?>
 </div>				

--- a/web/app/themes/mitlib-parent/inc/location-alert.php
+++ b/web/app/themes/mitlib-parent/inc/location-alert.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Template for alerts displayed on an individual location page.
+ *
+ * @package MITlib_Parent
+ * @since 0.2.1
+ */
+
+namespace Mitlib\Parent;
+
+$alert_title   = cf( 'alert_title' );
+$alert_content = cf( 'alert_content' );
+
+$no_html = array();
+
+$allowed_html = array(
+	'a' => array(
+		'href' => array(),
+	),
+	'em' => array(),
+	'strong' => array(),
+);
+
+?>
+<div class="libraryAlert">
+	<div class="location--alerts flex-container"><i class="icon-exclamation-sign"></i>
+		<div class="alertText">
+			<h3><?php echo wp_kses( $alert_title, $no_html ); ?></h3>
+			<p><?php echo wp_kses( $alert_content, $allowed_html ); ?></p>
+		</div>
+	</div>
+</div>

--- a/web/app/themes/mitlib-parent/templates/page-hours.php
+++ b/web/app/themes/mitlib-parent/templates/page-hours.php
@@ -240,26 +240,26 @@ tr:nth-child(even) td {
 			  <?php if ( get_field( 'study_24', $locationId ) ) { ?>
 			  <span class="hidden">|</span> <a class="space247" href="/study/24x7/" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>
 			  <?php } ?>
-			  <?php
-			  if ( get_field( 'alert_title', $locationId ) ) {
-				$alert_title = get_field( 'alert_title', $locationId );
-				$alert_content = get_field( 'alert_content', $locationId );
-				$no_html = array();
-				$allowed_html = array(
-					'a' => array(
-						'href' => array(),
-					),
-					'em' => array(),
-					'strong' => array(),
-				);
-			  ?>
+				<?php
+				if ( get_field( 'alert_title', $locationId ) ) {
+					$alert_title = get_field( 'alert_title', $locationId );
+					$alert_content = get_field( 'alert_content', $locationId );
+					$no_html = array();
+					$allowed_html = array(
+						'a' => array(
+							'href' => array(),
+						),
+						'em' => array(),
+						'strong' => array(),
+					);
+				?>
 				<div class="libraryAlert"> <i class="icon-exclamation-sign"></i>
 					<div class="alertText">
 						<div class="la-title"><?php echo wp_kses( $alert_title, $no_html ); ?></div>
 						<?php echo '<p>' . wp_kses( $alert_content, $allowed_html ) . '</p>'; ?>
 					</div>
 				</div>
-			  <?php } ?>
+				<?php } ?>
 			</div></td>
 			<?php for ( $i = 0;$i <= 6;$i++ ) { ?>
 				<?php

--- a/web/app/themes/mitlib-parent/templates/page-hours.php
+++ b/web/app/themes/mitlib-parent/templates/page-hours.php
@@ -86,9 +86,6 @@ $prevWeek = date( 'Y-n-j', strtotime( '-7 day', $today ) );
 $nextWeek = date( 'Y-n-j', strtotime( '+7 day', $today ) );
 $thisWeek = date( 'Y-n-j' );
 
-$alertTitle = cf( 'alert_title' );
-$alertContent = cf( 'alert_content' );
-
 ?>
 	
 <?php get_template_part( 'inc/breadcrumbs' ); ?>
@@ -243,13 +240,25 @@ tr:nth-child(even) td {
 			  <?php if ( get_field( 'study_24', $locationId ) ) { ?>
 			  <span class="hidden">|</span> <a class="space247" href="/study/24x7/" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>
 			  <?php } ?>
-			  <?php if ( get_field( 'alert_title', $locationId ) ) { ?>
-			  <div class="libraryAlert"> <i class="icon-exclamation-sign"></i>
-				<div class="alertText">
-			  <div class="la-title"><?php the_field( 'alert_title', $locationId ); ?></div>
-					<?php the_field( 'alert_content', $locationId ); ?>
-			  </div>
-			  </div>
+			  <?php
+			  if ( get_field( 'alert_title', $locationId ) ) {
+				$alert_title = get_field( 'alert_title', $locationId );
+				$alert_content = get_field( 'alert_content', $locationId );
+				$no_html = array();
+				$allowed_html = array(
+					'a' => array(
+						'href' => array(),
+					),
+					'em' => array(),
+					'strong' => array(),
+				);
+			  ?>
+				<div class="libraryAlert"> <i class="icon-exclamation-sign"></i>
+					<div class="alertText">
+						<div class="la-title"><?php echo wp_kses( $alert_title, $no_html ); ?></div>
+						<?php echo '<p>' . wp_kses( $alert_content, $allowed_html ) . '</p>'; ?>
+					</div>
+				</div>
 			  <?php } ?>
 			</div></td>
 			<?php for ( $i = 0;$i <= 6;$i++ ) { ?>


### PR DESCRIPTION
### Why are these changes being introduced:

* Location alerts are currently handled inconsistently between the to locations where they appear, and the documentation around the alerts is also inaccurate.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-446
* Please note that the ticket has links to content showing this change, and screenshots demonstrating how it renders.

### How does this address that need:

* This updates the instructions to site builders, clarifying which markup is supported in the alert title (none) and alert content (only a, em, and strong tags).

* The rendering templates for the hours grid and both location templates are updated to be consistent with the instructions to site builders. All markup is stripped (not escaped) from the title field, while all extraneous markup is stripped from the content field.

* As part of this change, the location alert handling is removed from both location templates, and handled in a new location-alert partial. The markup needed on the hours grid is fundamentally different, so that is still handled within the hours template itself.

### Document any side effects to this change:

* I cannot think of any.

## Developer

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected by this change.

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
