### PR TITLE
Remove domain-specific borders on links and images

### DIFF
--- a/web/app/themes/mitlib-parent/css/super-admin.css
+++ b/web/app/themes/mitlib-parent/css/super-admin.css
@@ -1,21 +1,8 @@
-/* Links to the production URL are in green. */
-body.admin-bar a[href^="https://libraries."],
-body.admin-bar a[href^="http://libraries."] {
-  border: 5px solid green;
-}
-
-body.admin-bar img[src^="https://libraries."],
-body.admin-bar img[src^="http://libraries."] {
-	border: 5px solid green;
-}
-
-/* Links to non-productions URLs are thicker and red, to be annoying and force changes. */
-body.admin-bar a[href^="https://libraries-"],
-body.admin-bar a[href^="http://libraries-"] {
-  border: 10px solid red;
-}
-
-body.admin-bar img[src^="https://libraries-"],
-body.admin-bar img[src^="http://libraries-"] {
-	border: 10px solid red;
-}
+/**
+ * This stylesheet is only sent to autheticated users in the Super Admin role.
+ * This is a helpful technique for highlighting specific content conditions that
+ * site builders need to watch for.
+ *
+ * Past examples of how we've used this feature are to highlight links using an
+ * insecure protocol, or references to specific domains which we need to remove.
+ */

--- a/web/app/themes/mitlib-parent/style.css
+++ b/web/app/themes/mitlib-parent/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib Parent
 Author: MIT Libraries
-Version: 0.2.1
+Version: 0.2.2
 Description: The parent theme for the MIT Libraries' Pentagram-designed identity.
 
 */


### PR DESCRIPTION
### Why are these changes being introduced:

* During the migration, we placed colored borders on content that came from the legacy production and staging servers, shown only to super admins, to help identify content that needed to change.

  Now that the migration is over and we have better search-replace tools these rules are a distraction and not needed.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-449

### How does this address that need:

* This removes the stylesheet rules that placed those borders around targeted content.
* It leaves in place the code to register and load the stylesheet for super admins only, as there are plausible tasks down the road where this feature will be needed.

### Document any side effects to this change:

* At this moment, there is an empty stylesheet in the parent theme that will be sent to super admins. This is a slight inefficiency, but I'm making a judgement call that it would be better to keep this in place for now because we'll field a request for similar flagging of content in the near future.

## Developer

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected by this change

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
