### PR TITLE
Tweak hours loader to handle dates outside defined terms/semesters

### DIFF
--- a/web/app/plugins/mitlib-pull-hours/js/hours-loader.js
+++ b/web/app/plugins/mitlib-pull-hours/js/hours-loader.js
@@ -207,9 +207,20 @@ var HoursLoader = {
 		// For each date in the week...
 		_.each(testweek, function(dayofweek) {
 			testday = new Date(dayofweek);
-			rebuildsemester = [];
+			// Define default vales, in case testday is beyond the range of defined semesters.
+			// Ideally these would be calculated from the Default Hours sheet.
+			semester_cache = 'Default-Hours.json';
+			testday.semestername = "Default Hours";
+			testday.start = '1/1/1970';
+			testday.end = '12/31/2100';
+			rebuildsemester = [
+				'Default Hours',
+				'1/1/1970',
+				'12/31/2100',
+				'Default-Hours.json'
+			];
 			// Cycle through each term, determining which it belongs to.
-			// (This is inefficient, I know...)
+			// (This is inefficient, I know... - could be _.every() with a break or return?)
 			_.each(testsemesters, function(semester) {
 				semester_start = new Date(semester[1]);
 				semester_end = new Date(semester[2]);


### PR DESCRIPTION
### Why are these changes being introduced:

The hours loader fails when the requested week includes any date which falls outside the list of defined semesters / terms.

The hours spreadsheet includes a "Default Hours" sheet, which is meant to account for this condition and display "TBA" values - but the code does not fall back to this correctly - and instead the entire second half of the loader fails when it attempts to load non-existant semester sheets.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/lm-451
* https://mitlibraries.atlassian.net/browse/engx-66

### How does this address that need:

This updates the logic in the assembleWeek method, defining some default values at the beginning of each date's calculation. Should the method fail to find a semester which contains that date, there will now be a set of values to allow the rest of the loader to operate, and look up the default values as intended.

### Document any side effects to this change:

Unfortunately, this change hard-codes some values that should instead be retrieved from the Default Hours sheet (although the actual values for each day are still looked up).

Additionally, it appears that the _.uniq() call on line 243 does not collapse these default values as it should - so we end up handling an array of repeated values when only one item is necessary. This does not cause any inaccurate information to be shown, but it is a minor inefficiency.

## Developer

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected by this change

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] There should be no impact to accessibility with this change

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
