### PR TITLE
Update escaping function for map links

### DIFF
--- a/web/app/themes/mitlib-parent/templates/page-map-locations.php
+++ b/web/app/themes/mitlib-parent/templates/page-map-locations.php
@@ -168,7 +168,7 @@ get_header(); ?>
 								<?php if ( $phone != '' ) : ?>
 									<?php echo esc_html( $phone ); ?>
 								<br/>
-								<?php endif; ?><a class="map" data-target="<?php echo esc_attr( $locationId ); ?>" href="#!<?php echo esc_url( $slug ); ?>">Map: <?php echo esc_html( $building ); ?></a>
+								<?php endif; ?><a class="map" data-target="<?php echo esc_attr( $locationId ); ?>" href="#!<?php echo esc_attr( $slug ); ?>">Map: <?php echo esc_html( $building ); ?></a>
 								<?php if ( $study24 == 1 ) : ?>
 									<br/>
 									<a class="space247" href="<?php echo esc_url( $gStudy24Url ); ?>" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>
@@ -227,7 +227,7 @@ get_header(); ?>
 							<?php if ( $phone != '' ) : ?>
 								<?php echo esc_html( $phone ); ?><br/>
 							<?php endif; ?>
-							<a class="map" data-target="<?php echo esc_attr( $locationId ); ?>" href="#!<?php echo esc_url( $slug ); ?>">Map: <?php echo esc_html( $building ); ?></a>
+							<a class="map" data-target="<?php echo esc_attr( $locationId ); ?>" href="#!<?php echo esc_attr( $slug ); ?>">Map: <?php echo esc_html( $building ); ?></a>
 						</li>
 					
 					<?php endwhile; // end of the loop. ?>					


### PR DESCRIPTION
### Why are these changes being introduced:

We are currently using the esc_url() function to escape map links, but this is not quite correct because the value being escaped is not a complete URL. While the function can handle document fragments, this output is not a complete fragment - so it is being converted to a value like 'http://barker-library` and the complete output is `href="#!http://barker-library"` instead of `href="#!barker-library"`

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/lm-454

### How does this address that need:

This changes which escaping fuction we are using, from esc_url to esc_attr. This results in the expected value being generated, while still taking advantage of the protection that content escaping offers.

The esc_attr function encodes characters like > < & " and ', which should be fine as the only expected characters are a-z and dashes.

### Document any side effects to this change:

There does not seem to be any - the value being escaped is the post name (also known as the slug, which is different than the title). Values will be things like "barker-library" or "docs".

## Developer

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
