### PR TITLE
[WIP] Investigating APTO vs bespoke page templates

### DIFF
--- a/web/app/themes/mitlib-child/templates/page-exhibits-feed.php
+++ b/web/app/themes/mitlib-child/templates/page-exhibits-feed.php
@@ -8,166 +8,144 @@
 
 namespace Mitlib\Child;
 
-get_header( 'child' );
+// Define the queries which will populate the three display sections.
+$current = array(
+	'posts_per_page'      => 10,
+	'ignore_sticky_posts' => false,
+	'post_type'           => 'exhibits',  // Only query exhibits.
+	'meta_key'            => 'start_date',  // Load up the event_date meta.
+	'orderby'             => 'start_date',
+	'order'               => 'DESC',      // Descending, so later events first.
+	'meta_query'          => array( // The meta_query is an array of query items.
+		array(
+			'key'     => 'start_date',     // Which meta to query.
+			'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
+			'compare' => '<=',             // Method of comparison.
+			'type'    => 'DATE',
+		),
+		array(
+			'relation' => 'OR',
+			array(
+				'key'     => 'end_date',        // Which meta to query.
+				'value'   => gmdate( 'Y-m-d' ), // Value for comparison.
+				'compare' => '>=',              // Method of comparison.
+				'type'    => 'DATE',
+			),
+			array(
+				'key'     => 'end_date',       // Which meta to query.
+				'value'   => '',               // Value for comparison.
+				'compare' => '=',              // Method of comparison.
+				'type'    => 'CHAR',
+			),
+		),
+	), // End meta_query array.
+); // End current query.
+
+$future = array(
+	'post_type'      => 'exhibits',    // Only query exhibits.
+	'meta_key'       => 'start_date',  // Load up the event_date meta.
+	'orderby'        => 'start_date',
+	'order'          => 'ASC',
+	'posts_per_page' => 10,       // Descending, so later events first.
+	'meta_query'     => array(
+		array(
+			'key'     => 'start_date',     // Which meta to query.
+			'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
+			'compare' => '>',             // Method of comparison.
+			'type'    => 'DATE',
+		), // The meta_query is an array of query items.
+	), // End meta_query array.
+); // End future query.
+
+$past = array(
+	'post_type'      => 'exhibits',  // Only query events.
+	'meta_key'       => 'end_date',  // Load up the event_date meta.
+	'orderby'        => 'end_date',
+	'order'          => 'DESC',      // Descending, so later events first.
+	'posts_per_page' => 5,
+	'meta_query'     => array(
+		array(
+			'key'     => 'end_date',       // Which meta to query.
+			'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
+			'compare' => '<',              // Method of comparison.
+			'type'    => 'DATE',
+		), // The meta_query is an array of query items.
+	), // End meta_query array.
+); // End past query.
+
 ?>
 
-	<?php get_template_part( 'inc/breadcrumbs', 'child' ); ?>
+<?php get_header( 'child' ); ?>
 
-	<div id="stage" class="inner" role="main">
+<?php get_template_part( 'inc/breadcrumbs', 'child' ); ?>
+
+<div id="stage" class="inner" role="main">
 
 	<?php get_template_part( 'inc/title-banner' ); ?>
 
-		<div id="content" class="content has-sidebar">
+	<div id="content" class="content has-sidebar">
 			
-			<div class="main-content">
+		<div class="main-content">
 
-		<?php
-
-			$current_query = new \WP_Query(
-				array(
-					'posts_per_page'      => 10,
-					'ignore_sticky_posts' => false,
-					'post_type'           => 'exhibits',  // Only query exhibits.
-					'meta_key'            => 'start_date',  // Load up the event_date meta.
-					'orderby'             => 'start_date',
-					'order'               => 'DESC',      // Descending, so later events first.
-					'meta_query'          => array( // The meta_query is an array of query items.
-						array(
-							'key'     => 'start_date',     // Which meta to query.
-							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
-							'compare' => '<=',             // Method of comparison.
-							'type'    => 'DATE',
-						),
-						array(
-							'relation' => 'OR',
-							array(
-								'key'     => 'end_date',        // Which meta to query.
-								'value'   => gmdate( 'Y-m-d' ), // Value for comparison.
-								'compare' => '>=',              // Method of comparison.
-								'type'    => 'DATE',
-							),
-							array(
-								'key'     => 'end_date',       // Which meta to query.
-								'value'   => '',               // Value for comparison.
-								'compare' => '=',              // Method of comparison.
-								'type'    => 'CHAR',
-							),
-						),
-					), // End meta_query array.
-				) // End array.
-			); // Close WP_Query constructor call.
-			?>
+			<?php $current_query = new \WP_Query( $current ); ?>
 
 			<div class="exhibits-feed-section">
 			
 				<h3 class="title-sub">Current Exhibits</h3>
-						 
+
 				<?php
-				if ( $current_query->have_posts() ) :
-					while ( $current_query->have_posts() ) :
+				if ( $current_query->have_posts() ) {
+					while ( $current_query->have_posts() ) {
 						$current_query->the_post(); // Loop for current exhibits.
 
 						get_template_part( 'inc/exhibits-detail' );
+					};
+					wp_reset_postdata();
+				} else {
+					echo '<p>There are no current exhibit announcements at this time. New exhibits are added throughout the year, so please check back.</p>';
+				}
+				?>
 
-					endwhile;
-
-						wp_reset_postdata();
-
-				else :
-					?>
-		 
-					<p><?php esc_html_e( 'There are no current exhibit announcements at this time. New exhibits are added throughout the year, so please check back.' ); ?></p>
-		 
-				<?php endif; ?>
-					   
 			</div>
 
-		<!-- END OF CURRENT EXHIBITS LOOP -->
-		   
+			<!-- END OF CURRENT EXHIBITS LOOP -->
 
-		<?php
+			<?php $future_query = new \WP_Query( $future ); ?>
 
-		$future_query = new \WP_Query(
-			array(
-				'post_type'      => 'exhibits',    // Only query exhibits.
-				'meta_key'       => 'start_date',  // Load up the event_date meta.
-				'orderby'        => 'start_date',
-				'order'          => 'ASC',
-				'posts_per_page' => 10,       // Descending, so later events first.
-				'meta_query'     => array(
-					array(
-						'key'     => 'start_date',     // Which meta to query.
-						'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
-						'compare' => '>',             // Method of comparison.
-						'type'    => 'DATE',
-					), // The meta_query is an array of query items.
-				), // End meta_query array.
-			) // End array.
-		); // Close WP_Query constructor call.
-		?>
-			
 			<div class="exhibits-feed-section">
-				
+
 				<h3 class="title-sub">Upcoming Exhibits</h3>
-				 
+
 				<?php
-				if ( $future_query->have_posts() ) :
-					while ( $future_query->have_posts() ) :
+				if ( $future_query->have_posts() ) {
+					while ( $future_query->have_posts() ) {
 						$future_query->the_post(); // Loop for future exhibits.
 
 						get_template_part( 'inc/exhibits-detail' );
-
-					endwhile;
-
+					};
 					wp_reset_postdata();
+				} else {
+					echo '<p>There are no upcoming exhibit announcements at this time. New exhibits are added throughout the year, so please check back.</p>';
+				}
+				?>
 
-				else :
-					?>
-	 
-					<p><?php esc_html_e( 'There are no upcoming exhibit announcements at this time. New exhibits are added throughout the year, so please check back.' ); ?></p>
-	 
-				<?php endif; ?>
-		
 			</div>
-		
-		
-			<!-- END OF UPCOMING EXHIBITS LOOP -->
-			 
-			 
-			<?php
 
-			$past_query = new \WP_Query(
-				array(
-					'post_type'      => 'exhibits',  // Only query events.
-					'meta_key'       => 'end_date',  // Load up the event_date meta.
-					'orderby'        => 'end_date',
-					'order'          => 'DESC',      // Descending, so later events first.
-					'posts_per_page' => 5,
-					'meta_query'     => array(
-						array(
-							'key'     => 'end_date',       // Which meta to query.
-							'value'   => gmdate( 'Y-m-d' ),  // Value for comparison.
-							'compare' => '<',              // Method of comparison.
-							'type'    => 'DATE',
-						), // The meta_query is an array of query items.
-					), // End meta_query array.
-				) // End array.
-			); // Close WP_Query constructor call.
-			?>
+			<!-- END OF UPCOMING EXHIBITS LOOP -->
+
+			<?php $past_query = new \WP_Query( $past ); ?>
 
 			<div class="exhibits-feed-section">
-			
+
 				<h3 class="title-sub">Past Exhibits</h3>
-				 
+
 				<?php
-				while ( $past_query->have_posts() ) :
+				while ( $past_query->have_posts() ) {
 					$past_query->the_post(); // Loop for events.
 
 					get_template_part( 'inc/exhibits-detail' );
-
-					wp_reset_postdata(); // Restore global post data stomped by the_post().
-
-				endwhile; // End of the loop.
+				};
+				wp_reset_postdata(); // Restore global post data stomped by the_post().
 				?>
 
 			</div>
@@ -175,15 +153,13 @@ get_header( 'child' );
 			<a class="button-secondary exhibits-button" href="/exhibits/past-exhibits/">View all past exhibits</a>
 
 		<!-- END OF PAST EXHIBITS LOOP -->
-	
-		
-		
-		</div>  <!-- main-content --> 
-	
-		<?php get_sidebar(); ?>
-	
-		</div>   <!-- content --> 
-			
-	</div>   <!-- stage --> 
-	 
+
+		</div>  <!-- .main-content --> 
+
+	<?php get_sidebar(); ?>
+
+	</div>   <!-- #content --> 
+
+</div>   <!-- #stage --> 
+
 <?php get_footer(); ?>


### PR DESCRIPTION
This is part of the work toward LM-436, investigating how to implement custom post orders (via APTO or via custom page templates)

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
