### PR TITLE
Remove antivirus plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,6 @@
     "wpackagist-plugin/acf-image-crop-add-on": "^1.4",
     "wpackagist-plugin/add-category-to-pages": "^1.2",
     "wpackagist-plugin/akismet": "^5.0",
-    "wpackagist-plugin/antivirus": "^1.4",
     "wpackagist-plugin/black-studio-tinymce-widget": "^2.7",
     "wpackagist-plugin/cf7-conditional-fields": "2.2.3",
     "wpackagist-plugin/cf7-to-zapier": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c04ebeeb4113740f107bf96f1853263a",
+    "content-hash": "756ec83d27dfeec7dad9283a2086069f",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -2640,24 +2640,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/akismet/"
-        },
-        {
-            "name": "wpackagist-plugin/antivirus",
-            "version": "1.4.4",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/antivirus/",
-                "reference": "tags/1.4.4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/antivirus.1.4.4.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/antivirus/"
         },
         {
             "name": "wpackagist-plugin/black-studio-tinymce-widget",


### PR DESCRIPTION
This removes the Antivirus plugin, which we've decided is unneeded.

## Developer

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected by this change

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
