### PR TITLE
Removes plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,15 +67,7 @@
     },
     {
       "type": "vcs",
-      "url": "https://github.com/mitlibraries/cpt-onomies"
-    },
-    {
-      "type": "vcs",
       "url": "https://github.com/mitlibraries/dynamic-menu-manager"
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/mitlibraries/wp-slug-trimmer"
     },
     {
       "type": "path",

--- a/composer.json
+++ b/composer.json
@@ -107,7 +107,6 @@
     "vlucas/phpdotenv": "^5.5",
     "wpackagist-plugin/acf-image-crop-add-on": "^1.4",
     "wpackagist-plugin/add-category-to-pages": "^1.2",
-    "wpackagist-plugin/akismet": "^5.0",
     "wpackagist-plugin/black-studio-tinymce-widget": "^2.7",
     "wpackagist-plugin/cf7-conditional-fields": "2.2.3",
     "wpackagist-plugin/cf7-to-zapier": "^2.2",

--- a/composer.json
+++ b/composer.json
@@ -67,10 +67,6 @@
     },
     {
       "type": "vcs",
-      "url": "https://github.com/mitlibraries/advanced-post-types-order"
-    },
-    {
-      "type": "vcs",
       "url": "https://github.com/mitlibraries/cpt-onomies"
     },
     {
@@ -94,7 +90,6 @@
     "google/apiclient": "^2.12",
     "mitlibraries/acf-location-field": "^1.0",
     "mitlibraries/dynamic-menu-manager": "^1.0",
-    "nsp-code/advanced-post-types-order": "^4.4",
     "oscarotero/env": "^2.1",
     "pantheon-systems/pantheon-mu-plugin": "*",
     "pantheon-upstreams/upstream-configuration": "dev-main",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "756ec83d27dfeec7dad9283a2086069f",
+    "content-hash": "b1d9af40b72619fdcc8251d439834806",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -2622,24 +2622,6 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/add-category-to-pages/"
-        },
-        {
-            "name": "wpackagist-plugin/akismet",
-            "version": "5.1",
-            "source": {
-                "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/akismet/",
-                "reference": "tags/5.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/akismet.5.1.zip"
-            },
-            "require": {
-                "composer/installers": "^1.0 || ^2.0"
-            },
-            "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/akismet/"
         },
         {
             "name": "wpackagist-plugin/black-studio-tinymce-widget",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1d9af40b72619fdcc8251d439834806",
+    "content-hash": "f8ef6523f2b858bdf56619206fb377b3",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -962,33 +962,6 @@
                 }
             ],
             "time": "2023-02-06T13:44:46+00:00"
-        },
-        {
-            "name": "nsp-code/advanced-post-types-order",
-            "version": "4.4.3",
-            "source": {
-                "type": "git",
-                "url": "git@github.com:MITLibraries/advanced-post-types-order.git",
-                "reference": "d01675d1cb2aeadf24a5447a5a9206ae2fcd7a9c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/MITLibraries/advanced-post-types-order/zipball/d01675d1cb2aeadf24a5447a5a9206ae2fcd7a9c",
-                "reference": "d01675d1cb2aeadf24a5447a5a9206ae2fcd7a9c",
-                "shasum": ""
-            },
-            "type": "wordpress-plugin",
-            "authors": [
-                {
-                    "name": "MIT Libraries"
-                }
-            ],
-            "description": "Order Post Types Objects using a Drag and Drop Sortable javascript capability",
-            "support": {
-                "source": "https://github.com/MITLibraries/advanced-post-types-order/tree/4.4.3",
-                "issues": "https://github.com/MITLibraries/advanced-post-types-order/issues"
-            },
-            "time": "2022-12-02T21:47:20+00:00"
         },
         {
             "name": "oscarotero/env",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8ef6523f2b858bdf56619206fb377b3",
+    "content-hash": "f6eb2172ed742628459f967062487e7e",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",


### PR DESCRIPTION
This removes two plugins which we've decided are no longer needed (Akismet and Advanced Post Types Order). It also removes references to some Github repositories for private plugins / repositories which we already removed, but didn't fully expunge.

The review app can be found in the usual place.

Ticket: https://mitlibraries.atlassian.net/browse/LM-452

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are impacted by this work

_Please note - there is a license code for Advanced Post Types Order, but we manage and activate that plugin separately from our code repository._

### Documentation

- [x] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
