### PR TITLE
Remove documentation on confirming plugins work

### DIFF
--- a/docs/howto/test-plugins.md
+++ b/docs/howto/test-plugins.md
@@ -1,3 +1,0 @@
-# How to confirm plugins are working
-
-[This document has moved to Google Docs for refinement](https://docs.google.com/document/d/12QEsYKVuILt_iQi4KMQS947Irz87HBBpjw7oJmywDGM/edit#)


### PR DESCRIPTION
### Why are these changes being introduced:

The how-to page on confirming whether all of our various plugins are working is something that the UX group has indicated an interest in helping to maintain, and the testing itself will be followed by both engineers and site builders.

Given this, it makes sense to move this documentation to the service documentation in Confluence.

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/lm-60

### How does this address that need:

This removes the stub page on confirming plugin operation, as the content has been moved to the Confluence space. This isn't a link that needs to be maintained in this way.

(We will eventually want to make sure that this repo links to the Confluence space at some level, but with the service being renamed soon I'm not sure what URLs will be changing in the next few days. We'll need a separate PR soon-ish once that happens)

### Document any side effects to this change:

None

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected by this work

### Documentation

- [x] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
