### PR TITLE
Upgrade PHP to 8.1

### DIFF
--- a/docs/howto/upgrading-php.md
+++ b/docs/howto/upgrading-php.md
@@ -47,7 +47,17 @@ consult the Site Health report (WordPress admin interface -> Tools -> Site
 Health). The report's Info tab includes a Server panel which reports the PHP
 version.
 
-4. Push branch to Github for code review
+4. Rebuild your local Lando environment with these changes
+
+Running `lando rebuild` will apply any needed container updates, now that the
+new PHP version is specified in `pantheon.upstream.yml`. The output of this
+command should include confirmation of the new PHP version, as the relevant
+pre-install command will be triggered during this process.
+
+The PHP version is also reported as part of the Site Health report within the
+WordPress dashboard (Tools -> Site Health -> Info tab - > Server panel).
+
+5. Push branch to Github for code review
 
 From this point, follow our standing practices for pull requests and code
 review.

--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -2,7 +2,7 @@ api_version: 1
 web_docroot: true
 # See https://pantheon.io/docs/pantheon-yml/#enforce-https--hsts for valid values.
 enforce_https: transitional
-php_version: 8.0
+php_version: 8.1
 database:
   version: 10.4
 build_step: true


### PR DESCRIPTION
* This updates our PHP version to 8.1 which is still under active development (instead of just getting security updates, which is the status of 8.0).
* It also updates the how-to page on language updates, adding a note about how to rebuild your local Lando environment to incorporate these changes.

Ticket: https://mitlibraries.atlassian.net/browse/PW-11

Confirming that the language has been updated can be done in a few places:

* As noted in this change, WordPress itself reports what PHP version it is using as part of the Site Health report in the administrative dashboard.
* Pantheon also reports what PHP version is used in any environment. From the Pantheon dashboard, look for the Settings link in the upper right of the page. One of the tabs on this modal box will be for PHP version, which will list all tiers (including multidevs in a collapsible region) and what PHP version is used.

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.
- [x] No CSS changes

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are implicated in this change

### Documentation

- [x] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
