### PR TITLE
Add tag template to News theme

### DIFF
--- a/web/app/themes/mitlib-news/content-single.php
+++ b/web/app/themes/mitlib-news/content-single.php
@@ -33,7 +33,7 @@ namespace Mitlib\News;
 				?>
 			</span>
 			<?php if ( has_category() ) : ?>
-			<span class="category-post">
+			<span class="category-post-single">
 		   
 				<?php
 				$category = get_the_category();

--- a/web/app/themes/mitlib-news/content-single.php
+++ b/web/app/themes/mitlib-news/content-single.php
@@ -8,85 +8,30 @@
 
 namespace Mitlib\News;
 
-	$category = get_the_category();
-	$type_post = get_post_type();
-	$subtitle;
-	$type;
+$category = get_the_category();
+$type_post = get_post_type();
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?> data-category="<?php echo esc_attr( $category[0]->slug ); ?>">
-	<div class="title-page  mySingle">
-		<?php if ( get_field( 'mark_as_new' ) === true ) : ?>
-		<span>New!</span>
-		<?php endif; ?>
+	<div class="title-page mySingle">
 		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
-		
-
 		<div class="entry-meta">
 			<span class="author">
 				By <?php the_author_posts_link(); ?>
 			</span>
 			<span class="date-post">
-				<?php
-				echo ' on ';
-				the_date();
-				?>
+				on <?php the_date(); ?>
 			</span>
-			<?php if ( has_category() ) : ?>
-			<span class="category-post-single">
-		   
-				<?php
-				$category = get_the_category();
-				?>
-				
-				
-				
-			 
-			</span>
-			<?php endif; ?>
 		</div><!-- .entry-meta -->
 	</div><!-- .title-page -->
 
 	<div class="entry-content mitContent">
-	
-		
-		 <?php
-			the_content();
-			// Echo type of Feature, if Feature.
-			if ( 'features' === $type_post ) {
-				$type = get_field( 'feature_type' );
-				echo 'The feature type is' . esc_html( $type );
-			}
-			// Echo start/end dates, if they exist.
-			if ( 'exhibits' === $type_post || 'updates' === $type_post ) {
-				$date_start = get_field( 'date_start' );
-				$date_end = get_field( 'date_end' );
-				echo '<div>Start date is ' . esc_html( $date_start ) . '</div>';
-				echo '<div>End date is ' . esc_html( $date_end ) . '</div>';
-			}
-			?>
-			
-			
-			<?php
+		<?php
+		the_content();
 
-			$date = \DateTime::createFromFormat( 'Ymd', get_field( 'event_date' ) );
-			// echo $date->format('d-m-Y');
-			// Check for events.
-			if ( 'post' == $type_post && 1 == get_field( 'is_event' ) ) {
-				?>
-			
-			<div class="event"><span class="grey">Event date </span> <?php echo esc_html( $date->format( 'F, j Y' ) ); ?><span class="grey"> starting at</span> <?php echo esc_html( get_field( 'event_start_time' ) ); ?> <span class="grey">
-																				<?php
-																				if ( get_field( 'event_end_time' ) != '' ) {
-																					?>
-				 and ending at</span> <?php echo esc_html( get_field( 'event_end_time' ) ); } ?></div>
-				
-		
-				<?php
-			}
-			?>
-			
-
-	</div><!-- .entry-content -->
-
+		if ( 'post' == $type_post && 1 == get_field( 'is_event' ) ) {
+			get_template_part( 'inc/events' );
+		}
+		?>
+	</div>
 </article><!-- #post-## -->

--- a/web/app/themes/mitlib-news/style.css
+++ b/web/app/themes/mitlib-news/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib News
 Author: MIT Libraries
-Version: 0.2.0
+Version: 0.3.0
 Description: A child theme of the MIT Libraries' parent, focused on News features and content.
 Template: mitlib-parent
 
@@ -832,6 +832,9 @@ h2.grid {
 	padding: 0px;
 	padding-left: 8px;
 }
+.mitContent {
+	overflow: auto;
+}
 .mitContent h2, .mitContent h3, .mitContent h4 {
 	margin: 0px;
 	padding: 0px;
@@ -871,6 +874,10 @@ article {
 	background-color: white;
 	padding-left: 20px;
 	padding-right: 20px
+}
+.tag article {
+	padding-top: 10px;
+	margin-bottom: 20px;
 }
 .classCheck:nth-child(n+4) {
     display: none;

--- a/web/app/themes/mitlib-news/tag.php
+++ b/web/app/themes/mitlib-news/tag.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * The template for displaying all content with a single tag.
+ *
+ * @package MITlib_News
+ * @since 0.3.0
+ */
+
+namespace Mitlib\News;
+
+get_header();
+?>
+
+<?php get_template_part( 'inc/sub-header' ); ?>
+
+<div id="content" role="main">
+	<?php if ( have_posts() ) : ?>
+		<div class="container container-fluid">
+			<div class="row">
+				<h1 class="lib-header">Tag: <strong><?php echo esc_html( single_tag_title( '', false ) ); ?></strong></h1>
+				<?php
+				while ( have_posts() ) :
+					the_post();
+					get_template_part( 'content', 'single' );
+				endwhile;
+				?>
+				<?php \Mitlib\Parent\content_nav( 'nav-below' ); ?>
+			</div>
+		</div>
+	<?php endif; ?>
+</div><!-- #content -->
+
+<div class="container">
+<?php get_footer(); ?>

--- a/web/app/themes/mitlib-parent/style.css
+++ b/web/app/themes/mitlib-parent/style.css
@@ -443,7 +443,7 @@ img.wp-smiley,
 .nav-previous,
 .previous-image {
 	float: left;
-	width: 50%;
+	width: 48%;
 }
 .meta-nav {
 	position: relative;
@@ -454,7 +454,7 @@ img.wp-smiley,
 .next-image {
 	float: right;
 	text-align: right;
-	width: 50%;
+	width: 48%;
 }
 .nav-single + .comments-area,
 #comment-nav-above {


### PR DESCRIPTION
This makes the tag template of the News theme into something usable. As a stretch goal, it also refactors the `content-single.php` partial into a more usable and sustainable condition in a separate commit.

These changes will result in a more usable display of content for visitors who click a link on the front page of DSpace@MIT.

Links to the review app and more context are in the linked ticket.

Ticket: https://mitlibraries.atlassian.net/browse/PW-55

Note: during evaluation of this change via ANDI, I realized that there are some color contrast problems in the News theme. They are not introduced with this change, but they exist in the tag template because of how the author line (and event information) are rendered. I've created https://mitlibraries.atlassian.net/browse/PW-56 in the backlog to tackle this issue among our other work.

## Developer

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected by this change

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
New ticket: https://mitlibraries.atlassian.net/browse/PW-56

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
