### PR TITLE
Adds opengraph partial to slim header

### DIFF
--- a/web/app/themes/mitlib-child/header-slim.php
+++ b/web/app/themes/mitlib-child/header-slim.php
@@ -21,6 +21,7 @@ namespace Mitlib\Child;
 <!--<meta name="viewport" content="width=device-width" />-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title><?php wp_title( '|', true, 'right' ); ?></title>
+<?php get_template_part( 'inc/header', 'opengraph' ); ?>
 <link rel="profile" href="http://gmpg.org/xfn/11" />
 <link rel="pingback" href="<?php bloginfo( 'pingback_url' ); ?>" />
 <?php wp_head(); ?>

--- a/web/app/themes/mitlib-parent/functions.php
+++ b/web/app/themes/mitlib-parent/functions.php
@@ -501,7 +501,7 @@ add_filter( 'body_class', 'Mitlib\Parent\customize_body_class' );
  * @return int The maximum number of words to include from the excerpt.
  */
 function custom_excerpt_length( $length ) {
-	return 9999;
+	return 100;
 }
 add_filter( 'excerpt_length', 'Mitlib\Parent\custom_excerpt_length', 999 );
 

--- a/web/app/themes/mitlib-parent/functions.php
+++ b/web/app/themes/mitlib-parent/functions.php
@@ -495,6 +495,17 @@ function customize_body_class( $classes ) {
 add_filter( 'body_class', 'Mitlib\Parent\customize_body_class' );
 
 /**
+ * Defines a new value for the length of the excerpt.
+ *
+ * @param int $length Number of words to include in the excerpt.
+ * @return int The maximum number of words to include from the excerpt.
+ */
+function custom_excerpt_length( $length ) {
+	return 9999;
+}
+add_filter( 'excerpt_length', 'Mitlib\Parent\custom_excerpt_length', 999 );
+
+/**
  * ============================================================================
  * ============================================================================
  * These functions are defined here, without adding them via add_action. They


### PR DESCRIPTION
## Developer

### Why are these changes being introduced:

There are two current problems with our use of OpenGraph headers on the WordPress network:
1. The themes don't currently always include the headers, because one template doesn't call for that partial.
2. The `og_description` tag uses the default behavior by WordPress, which is to truncate the description at 55 words.

As a result of these changes, our attempts to harvest site content in TIMDEX are hamstrung in some cases (content that uses that header, and content that is very long).

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/pw-60

### How does this address that need:

1. The slim header which previously did not include the opengraph partial now does.
2. We define a custom length for the description of 100 words - (instead of the initially-proposed 9,999 words).

### Document any side effects to this change:

* These changes make our pages heavier in bandwidth terms, because we are including two copies of the body in every HTML response.
* There may yet be other needed changes to our OpenGraph implementation, depending on the evolving needs of the TIMDEX harvester - but that is more accurately described as "future work to do" or "problems not yet solved" rather than "side effects caused by this change".

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are implicated by this change

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
