### PR TITLE
Update time handling in pull events

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -199,7 +199,7 @@ Maintaining these symlinks involves two steps. For a hypothetical site like `lib
 
 * `lando start` will get your local containers running.
 * `lando pull` will prompt for the environment on Pantheon from which to grab the database and files. (Our default workflow is to not prompt for copying code directly from Pantheon)
-* `lando wp search-replace dev-mitlib-wp-network.pantheonsite.io mitlib-wp-network.lndo.site --url=dev-mitlib-wp-network.pantheonsite.io --network` will cleanup the database to work with our local site name. Note: `dev-mitlib...` would change to match whichever multidev you pulled data from in the previous step. This assumes `dev` but if you chose `engxhallo`, the prefix would change to `engxhallo-mitlib`. If the command finishes saying it made 0 replacements, it's likely you ran a command for replacing that didn't match the multidev you pulled from.
+* `lando wp search-replace www-dev.libraries.mit.edu mitlib-wp-network.lndo.site --url=www-dev.libraries.mit.edu --network` will cleanup the database to work with our local site name. Note: `dev-mitlib...` would change to match whichever multidev you pulled data from in the previous step. This assumes `dev` but if you chose `engxhallo`, the prefix would change to `engxhallo-mitlib`. If the command finishes saying it made 0 replacements, it's likely you ran a command for replacing that didn't match the multidev you pulled from.
 * Access the site at: `https://mitlib-wp-network.lndo.site`
 
 You can completely start your local environment over with `lando destroy` - after which you should follow each step in the above process.

--- a/web/app/plugins/mitlib-pull-events/class-pull-events-plugin.php
+++ b/web/app/plugins/mitlib-pull-events/class-pull-events-plugin.php
@@ -118,15 +118,15 @@ class Pull_Events_Plugin {
 				if ( isset( $val['event']['event_instances'][0]['event_instance'] ) ) {
 					$calendar_id = $val['event']['event_instances'][0]['event_instance']['id'];
 					$start = new DateTimeImmutable( $val['event']['event_instances'][0]['event_instance']['start'] );
-					$startdate = date_format($start, 'Ymd');
-					$starttime = date_format($start, 'h:i A');
+					$startdate = date_format( $start, 'Ymd' );
+					$starttime = date_format( $start, 'h:i A' );
 					$end = '';
 					$enddate = '';
 					$endtime = '';
 					if ( isset( $val['event']['event_instances'][0]['event_instance']['end'] ) ) {
 						$end = new DateTimeImmutable( $val['event']['event_instances'][0]['event_instance']['end'] );
-						$startdate = date_format($end, 'Ymd');
-						$endtime = date_format($end, 'h:i A');
+						$startdate = date_format( $end, 'Ymd' );
+						$endtime = date_format( $end, 'h:i A' );
 					}
 				}
 				if ( isset( $val['event']['localist_url'] ) ) {

--- a/web/app/plugins/mitlib-pull-events/class-pull-events-plugin.php
+++ b/web/app/plugins/mitlib-pull-events/class-pull-events-plugin.php
@@ -117,20 +117,16 @@ class Pull_Events_Plugin {
 				}
 				if ( isset( $val['event']['event_instances'][0]['event_instance'] ) ) {
 					$calendar_id = $val['event']['event_instances'][0]['event_instance']['id'];
-					$start = strtotime( $val['event']['event_instances'][0]['event_instance']['start'] );
-					$startdate = gmdate( 'Ymd', $start );
-					$workingtime = new DateTime( gmdate( 'h:i A', $start ) );
-					$workingtime->setTimezone( new DateTimeZone( get_option( 'timezone_string' ) ) );
-					$starttime = $workingtime->format( 'h:i A' );
+					$start = new DateTimeImmutable( $val['event']['event_instances'][0]['event_instance']['start'] );
+					$startdate = date_format($start, 'Ymd');
+					$starttime = date_format($start, 'h:i A');
 					$end = '';
 					$enddate = '';
 					$endtime = '';
 					if ( isset( $val['event']['event_instances'][0]['event_instance']['end'] ) ) {
-						$end = strtotime( $val['event']['event_instances'][0]['event_instance']['end'] );
-						$enddate = gmdate( 'Ymd', $end );
-						$workingtime = new DateTime( gmdate( 'h:i A', $end ) );
-						$workingtime->setTimezone( new DateTimeZone( get_option( 'timezone_string' ) ) );
-						$endtime = $workingtime->format( 'h:i A' );
+						$end = new DateTimeImmutable( $val['event']['event_instances'][0]['event_instance']['end'] );
+						$startdate = date_format($end, 'Ymd');
+						$endtime = date_format($end, 'h:i A');
 					}
 				}
 				if ( isset( $val['event']['localist_url'] ) ) {


### PR DESCRIPTION
Why are these changes being introduced:

* pull events was not handling crossing time changes like when the pull happened in EDT but the event was in EST

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/PW-64

How does this address that need:

* Creates a `DateTimeImmutable` which understands timezones then just formats that time directly

Document any side effects to this change:

* Also updated docs on how to pull data from dev to account for our actual dev tier name

## Developer

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [x] All new secrets have been added to Pantheon tiers
- [x] Relevant secrets have been updated in Github Actions
- [x] All new secrets documented in README

### Documentation

- [x] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
