### PR TITLE
Bump parent theme version for testing

### DIFF
--- a/web/app/themes/mitlib-parent/style.css
+++ b/web/app/themes/mitlib-parent/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib Parent
 Author: MIT Libraries
-Version: 0.3
+Version: 0.4
 Description: The parent theme for the MIT Libraries' Pentagram-designed identity.
 
 */


### PR DESCRIPTION
This is a small, meaningless change - bumping the parent theme version string. This is prompted by a request from Pantheon support to investigate an apparent deploy failure while promoting the previous PR changes.

This will be merged without the usual code review. We can review this tomorrow as a team within EngX.