### PR TITLE
Add IP-based block list to wp-config

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -259,7 +259,7 @@ Please see the readme for that project for [installation](https://github.com/pan
 #### Optional application secrets
 
 - `SENTRY_DSN` Unique identifier for this project within Sentry.
-
+- `BLOCKED_IPS` A space-separated list of IP addresses which should be blocked from getting a Wordpress response.
 
 ### Environment variables
 

--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -69,8 +69,30 @@ if ( ! empty( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
       define( 'WP_SENTRY_VERSION', 'v1' );
       define( 'WP_SENTRY_ENV', $_ENV['PANTHEON_ENVIRONMENT'] );
     }
-  }
 
+    // Blocked IP address handling - defined as a space-separated string in secrets, and
+    // parsed to an array.
+    if ( array_key_exists( 'BLOCKED_IPS', $secrets ) ) {
+      define( 'BLOCKED_IPS', $secrets['BLOCKED_IPS'] );
+    }
+  }
+}
+
+/**
+ * Respond with a 403 error message if the user IP address is on our block list.
+ *
+ * This assumes that BLOCKED_IPS is a string that can be exploded to an array of values.
+ * It also assumes that the block list consists of individual IP addresses, and not
+ * ranges that need to be calculated.
+ */
+if ( defined( 'BLOCKED_IPS' ) ) {
+  $array_blocked_ips = explode( " ", BLOCKED_IPS );
+  $request_remote_addr = $_SERVER['REMOTE_ADDR'];
+
+  if ( in_array($request_remote_addr, $array_blocked_ips) ) {
+    header( 'HTTP/1.0 403 Forbidden' );
+    exit;
+  }
 }
 
 /**


### PR DESCRIPTION
### Why are these changes being introduced:

We are starting to see problematic site traffic, and want to have a way to block access to the application selectively.

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/pw-86

### How does this address that need:

This adds an ability to block specific IP addresses from getting site responses, sending a 403 status message instead. The list of blocked IP addresses is managed via environment variables.

### Document any side effects to this change:

There is a small increase in site overhead, as every page load will now be checked against the IP block list. However, this is done at the PHP level, without needing to spin up WordPress itself.

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [x] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [x] All new secrets documented in README

### Documentation

- [x] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] The UI is not affected by this work.

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
