### PR TITLE
Add location alert fields to homepage widget

### DIFF
--- a/web/app/mu-plugins/mitlib-post/data/location/group_58e22931ab9f5.json
+++ b/web/app/mu-plugins/mitlib-post/data/location/group_58e22931ab9f5.json
@@ -41,6 +41,25 @@
             "delay": 0
         },
         {
+            "key": "field_6643c15f0075d",
+            "label": "Alert Frontpage",
+            "name": "alert_frontpage",
+            "type": "wysiwyg",
+            "instructions": "This field is shown only on the front page hours widget. The content is automatically wrapped in a paragraph tag. The only allowed HTML tag is for links (a tags).",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "tabs": "all",
+            "toolbar": "full",
+            "media_upload": 0,
+            "delay": 0
+        },
+        {
             "key": "field_24",
             "label": "Display Page",
             "name": "display_page",
@@ -990,5 +1009,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1671581913
+    "modified": 1715716606
 }

--- a/web/app/plugins/mitlib-pull-hours/src/class-display-widget-frontpage.php
+++ b/web/app/plugins/mitlib-pull-hours/src/class-display-widget-frontpage.php
@@ -84,6 +84,44 @@ class Display_Widget_Frontpage extends \WP_Widget {
 	}
 
 	/**
+	 * This function accepts the post ID of a location record, which will be used
+	 * to check if that location has its alert populated. If either of the two
+	 * fields for the location alert (alert_title or alert_content) are populated,
+	 * that content will be shown in a div.
+	 *
+	 * The function does not return anything.
+	 *
+	 * @param string $location_id The ID of a location record to look up.
+	 *
+	 * @return void
+	 */
+	public function location_alert( $location_id ) {
+		$allowed_html = array(
+			'a' => array(
+				'href' => array(),
+			),
+			'p' => array(),
+		);
+
+		$query_args = array(
+			'post_type' => 'location',
+			'p' => $location_id,
+			'post_status' => 'publish',
+		);
+		$locations = new \WP_Query( $query_args );
+
+		while ( $locations->have_posts() ) {
+			$locations->the_post();
+			$alert_frontpage = get_field( 'alert_frontpage' );
+			if ( $alert_frontpage ) {
+				echo '<div class="location-alert">';
+				echo wp_kses( $alert_frontpage, $allowed_html );
+				echo '</div>';
+			}
+		}
+	}
+
+	/**
 	 * Sanitize widget form values as they are saved.
 	 *
 	 * @see WP_Widget::form()

--- a/web/app/plugins/mitlib-pull-hours/templates/display-widget-frontpage.php
+++ b/web/app/plugins/mitlib-pull-hours/templates/display-widget-frontpage.php
@@ -14,18 +14,30 @@
 		<h3><a class="name-location" href="/barker">Barker Library</a></h3><div class="hours"><span data-location-hours="Barker Library"></span> today</div><div class="location-info"><a href="/locations/#!barker-library" class="map-location">10-500</a><a href="tel:617-253-0968" class="phone"><span class="number">617-253-0968</span></a></div>
 	</div>
 </div>
+<?php
+	// Load location alerts for Barker (post 322).
+	$this->location_alert( 322 );
+?>
 <div class="location">
 	<a href="/dewey" aria-labelledby="dewey" class="img-loc dewey"><span class="sr" id="dewey">Dewey Library</span></a>
 	<div class="wrap-loc-info">
 		<h3><a class="name-location" href="/dewey">Dewey Library</a></h3><div class="hours"><span data-location-hours="Dewey Library"></span> today</div><div class="location-info"><a href="/locations/#!dewey-library" class="map-location">E53-100</a><a href="tel:617-253-5676" class="phone"><span class="number">617-253-5676</span></a></div>
 	</div>
 </div>
+<?php
+	// Load location alerts for Dewey (post 313).
+	$this->location_alert( 313 );
+?>
 <div class="location">
 	<a href="/hayden" aria-labelledby="hayden" class="img-loc hayden"><span class="sr" id="hayden">Hayden Library</span></a>
 	<div class="wrap-loc-info">
 		<h3><a class="name-location" href="/hayden">Hayden Library</a></h3><div class="hours"><span data-location-hours="Hayden Library"></span> today</div> <div class="location-info"><a href="/locations/#!hayden-library" class="map-location">14S-100</a><a href="tel:617-253-5671" class="phone"><span class="number">617-253-5671</span></a></div>
 	</div>
 </div>
+<?php
+	// Load location alerts for Hayden (post 452).
+	$this->location_alert( 452 );
+?>
 <a href="#0" class="show-more hidden-non-mobile">
 	<svg class="icon-arrow-down" version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" width="16.3" height="9.4" viewBox="2.7 8.3 16.3 9.4" enable-background="new 2.7 8.3 16.3 9.4" xml:space="preserve"><path d="M18.982 9.538l-8.159 8.159L2.665 9.538l1.284-1.283 6.875 6.875 6.875-6.875L18.982 9.538z"/></svg>Show 3 More
 </a>
@@ -35,16 +47,28 @@
 		<h3><a class="name-location" href="/rotch">Rotch Library</a></h3><div class="hours"><span data-location-hours="Rotch Library"></span> today</div><div class="location-info"><a href="/locations/#!rotch-library" class="map-location">7-238</a><a href="tel:617-258-5592" class="phone"><span class="number">617-258-5592</span></a></div>
 	</div>
 </div>
+<?php
+	// Load location alerts for Rotch (post 359).
+	$this->location_alert( 359 );
+?>
 <div class="location hidden-mobile inactive-mobile">
 	<a href="/distinctive-collections" aria-labelledby="dc" class="img-loc archives"><span class="sr" id="dc">Distinctive Collections Reading Room</span></a>
 	<div class="wrap-loc-info">
 		<h3><a class="name-location" href="/distinctive-collections">Distinctive Collections Reading Room</a></h3><div class="hours"><span data-location-hours="Distinctive Collections"></span> today</div><div class="location-info"><a href="/locations/#!distinctive-collections" class="map-location">14N-118</a><a href="tel:617-253-5690" class="phone"><span class="number">617-253-5690</span></a></div>
 	</div>
 </div>
+<?php
+	// Load location alerts for Distinctive Collections (post 504).
+	$this->location_alert( 504 );
+?>
 <div class="location hidden-mobile inactive-mobile">
 	<a href="/music" aria-labelledby="lewis" class="img-loc lewis"><span class="sr" id="lewis">Lewis Music Library</span></a>
 	<div class="wrap-loc-info">
 		<h3><a class="name-location" href="/music">Lewis Music Library</a></h3><div class="hours"><span data-location-hours="Lewis Music Library"></span> today</div><div class="location-info"><a href="/locations/#!lewis-music-library" class="map-location">14E-109</a><a href="tel:617-253-5689" class="phone"><span class="number">617-253-5689</span></a></div>
 	</div>
 </div>
+<?php
+	// Load location alerts for Lewis (post 473).
+	$this->location_alert( 473 );
+?>
 <a href="/hours" class="button-primary--green full add-margin link-hours">All hours &amp; locations</a>

--- a/web/app/themes/mitlib-parent/css/scss/partials/_home.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_home.scss
@@ -199,10 +199,14 @@ body.page-home {
 			}
 		}
 
-		.location-hayden-reno {
+		.location-alert {
 			padding: .5rem 1em;
 			color: #008700;
 			margin: 0;
+
+			@include bp-tablet--portrait {
+				padding: 0 1rem 1rem
+			}
 
 			p {
 				margin-bottom: 0 !important;

--- a/web/app/themes/mitlib-parent/style.css
+++ b/web/app/themes/mitlib-parent/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib Parent
 Author: MIT Libraries
-Version: 0.4
+Version: 0.5
 Description: The parent theme for the MIT Libraries' Pentagram-designed identity.
 
 */


### PR DESCRIPTION
## Developer

This change adds a field to the Location data model, along with display logic in the homepage hours widget, which combined allow the UX staff to manage alerts for the locations on the platform homepage.

This change does not affect the existing platform-wide alerts, nor the existing location-based alerts shown on the hours grid or the location homepages.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/pw-93

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated

### Additional context needed to review

There are links to the review app in the Jira ticket.

## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
