### PR TITLE
Adds link to MIT Libraries Dataverse to more tab

### DIFF
--- a/web/app/plugins/mitlib-multisearch-widget/templates/tab-more-alma.php
+++ b/web/app/plugins/mitlib-multisearch-widget/templates/tab-more-alma.php
@@ -18,7 +18,7 @@
 			<li><a href="https://dspace.mit.edu">DSpace@MIT</a></li>
 			<li><a href="https://archivesspace.mit.edu/">ArchivesSpace</a></li>
 			<li><a href="https://dataverse.harvard.edu/dataverse/mit-libraries">MIT Libraries Dataverse</a></li>
-			<li><a href="http://libraries.mit.edu/experts/">Search tools by subject</a></li>
+			<li><a href="/experts/">Search tools by subject</a></li>
 			<li><a href="/search">More search options: images, data, etc.</a></li>
 		</ul>
 	</div>
@@ -26,7 +26,7 @@
 		<h3 class="header-col">Other useful tools</h3>
 		<ul>
 			<li><a href="https://libraries.mit.edu/worldcat">WorldCat</a></li>
-			<li><a href="http://libguides.mit.edu/google/googlescholar">Google Scholar for MIT</a></li>
+			<li><a href="https://libguides.mit.edu/google/googlescholar">Google Scholar for MIT</a></li>
 		</ul>
 	</div>
 	<div class="col col-3">

--- a/web/app/plugins/mitlib-multisearch-widget/templates/tab-more-alma.php
+++ b/web/app/plugins/mitlib-multisearch-widget/templates/tab-more-alma.php
@@ -17,6 +17,7 @@
 			<li><a href="/theses">MIT theses</a></li>
 			<li><a href="https://dspace.mit.edu">DSpace@MIT</a></li>
 			<li><a href="https://archivesspace.mit.edu/">ArchivesSpace</a></li>
+			<li><a href="https://dataverse.harvard.edu/dataverse/mit-libraries">MIT Libraries Dataverse</a></li>
 			<li><a href="http://libraries.mit.edu/experts/">Search tools by subject</a></li>
 			<li><a href="/search">More search options: images, data, etc.</a></li>
 		</ul>


### PR DESCRIPTION
## Developer

This adds a link to the Libraries' Dataverse instance to the "More..." tab of the multisearch widget.

It leaves all sorts of things in place, and does not try to make any process improvements for editing this content in the future.

### Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/pw-97
* https://mitlibraries.atlassian.net/browse/PPD-165

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
