### PR TITLE
Add content-audit-exporter plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,6 @@
   ],
   "require": {
     "php": ">=7.4",
-    "wpengine/advanced-custom-fields-pro": "^5",
     "composer/installers": "^2.2",
     "connectthink/wp-scss": "^2.4@beta",
     "cweagans/composer-patches": "^1.7",
@@ -102,6 +101,7 @@
     "wpackagist-plugin/classic-widgets": "^0.3.0",
     "wpackagist-plugin/cms-tree-page-view": "^1.6",
     "wpackagist-plugin/contact-form-7": "^5.6",
+    "wpackagist-plugin/content-audit-exporter": "^1.1",
     "wpackagist-plugin/custom-post-type-ui": "^1.13",
     "wpackagist-plugin/enable-media-replace": "^4.0",
     "wpackagist-plugin/filter-page-by-template": "^3.1",
@@ -125,7 +125,8 @@
     "wpackagist-plugin/wp-native-php-sessions": "*",
     "wpackagist-plugin/wp-security-audit-log": "^4.4",
     "wpackagist-plugin/wp-sentry-integration": "^7.0",
-    "wpackagist-plugin/wpcf7-recaptcha": "^1.4"
+    "wpackagist-plugin/wpcf7-recaptcha": "^1.4",
+    "wpengine/advanced-custom-fields-pro": "^5"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1f28b988c81f581c6cd6d29ed8a78bb",
+    "content-hash": "703ec7cde8cc7b376ca41f50167e77e2",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -2760,6 +2760,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/contact-form-7/"
+        },
+        {
+            "name": "wpackagist-plugin/content-audit-exporter",
+            "version": "1.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/content-audit-exporter/",
+                "reference": "tags/1.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/content-audit-exporter.1.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/content-audit-exporter/"
         },
         {
             "name": "wpackagist-plugin/custom-post-type-ui",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -50,6 +50,7 @@
   <exclude-pattern>web/app/plugins/classic-widgets</exclude-pattern>
   <exclude-pattern>web/app/plugins/cms-tree-page-view</exclude-pattern>
   <exclude-pattern>web/app/plugins/contact-form-7</exclude-pattern>
+  <exclude-pattern>web/app/plugins/content-audit-exporter</exclude-pattern>
   <exclude-pattern>web/app/plugins/cpt-onomies</exclude-pattern>
   <exclude-pattern>web/app/plugins/custom-post-type-ui</exclude-pattern>
   <exclude-pattern>web/app/plugins/dynamic-menu-manager</exclude-pattern>


### PR DESCRIPTION
## Developer

This adds the [Content Audit Exporter plugin](https://wordpress.org/plugins/content-audit-exporter/), as requested by UXWS in PW-94.

https://mitlibraries.atlassian.net/browse/PW-94

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are impacted

### Documentation

- [x] Project documentation has been updated
- [ ] No documentation changes are needed

The plugin has been added to https://mitlibraries.atlassian.net/wiki/spaces/IWC/pages/3405316102/WordPress+Plugin+Testing#Content-Audit-Exporter

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] No UI are impacted by this change

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
