### PR TITLE
Remove polyfill from hours plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -124,7 +124,7 @@
     "wpackagist-plugin/wp-mail-smtp": "^3.6",
     "wpackagist-plugin/wp-native-php-sessions": "*",
     "wpackagist-plugin/wp-security-audit-log": "^4.4",
-    "wpackagist-plugin/wp-sentry-integration": "^6.0",
+    "wpackagist-plugin/wp-sentry-integration": "^7.0",
     "wpackagist-plugin/wpcf7-recaptcha": "^1.4"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b3d9be6b3786ccc9f831e3056a97871",
+    "content-hash": "d1f28b988c81f581c6cd6d29ed8a78bb",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -3159,15 +3159,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-sentry-integration",
-            "version": "6.26.0",
+            "version": "7.17.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-sentry-integration/",
-                "reference": "tags/6.26.0"
+                "reference": "tags/7.17.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-sentry-integration.6.26.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-sentry-integration.7.17.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"

--- a/web/app/plugins/mitlib-pull-hours/mitlib-pull-hours.php
+++ b/web/app/plugins/mitlib-pull-hours/mitlib-pull-hours.php
@@ -3,7 +3,7 @@
  * Plugin Name:   MITlib Pull Hours
  * Plugin URI:    https://github.com/MITLibraries/mitlib-pull-hours
  * Description:   A WordPress plugin that populates a local JSON cache from a Google Spreadsheet.
- * Version:       1.0.0
+ * Version:       1.1
  * Author:        MIT Libraries
  * Author URI:    https://github.com/MITLibraries
  * Licence:       GPL2

--- a/web/app/plugins/mitlib-pull-hours/src/class-display-widget-frontpage.php
+++ b/web/app/plugins/mitlib-pull-hours/src/class-display-widget-frontpage.php
@@ -146,8 +146,7 @@ class Display_Widget_Frontpage extends \WP_Widget {
 		// Register javascript.
 		wp_register_script( 'moment', plugin_dir_url( __FILE__ ) . '../js/libs/moment.min.js', array(), '2.8.3', true );
 		wp_register_script( 'underscore', plugin_dir_url( __FILE__ ) . '../js/libs/underscore.min.js', array(), '1.7.0', true );
-		wp_register_script( 'polyfill', '//polyfill.io/v3/polyfill.js?version=3.52.1', array(), '3.52.1', true );
-		wp_register_script( 'hours-loader', plugin_dir_url( __FILE__ ) . '../js/hours-loader.js', array( 'jquery', 'moment', 'underscore', 'polyfill' ), '1.10.0', true );
+		wp_register_script( 'hours-loader', plugin_dir_url( __FILE__ ) . '../js/hours-loader.js', array( 'jquery', 'moment', 'underscore' ), '1.10.0', true );
 		wp_enqueue_script( 'hours-loader' );
 
 		$instance = null; // There are no publicly exposed settings for this widget.

--- a/web/app/plugins/mitlib-pull-hours/src/class-display-widget-slim.php
+++ b/web/app/plugins/mitlib-pull-hours/src/class-display-widget-slim.php
@@ -115,8 +115,7 @@ class Display_Widget_Slim extends \WP_Widget {
 		// Register javascript.
 		wp_register_script( 'moment', plugin_dir_url( __FILE__ ) . '../js/libs/moment.min.js', array(), '2.8.3', true );
 		wp_register_script( 'underscore', plugin_dir_url( __FILE__ ) . '../js/libs/underscore.min.js', array(), '1.7.0', true );
-		wp_register_script( 'polyfill', '//polyfill.io/v3/polyfill.js?version=3.52.1', array(), '3.52.1', true );
-		wp_register_script( 'hours-loader', plugin_dir_url( __FILE__ ) . '../js/hours-loader.js', array( 'jquery', 'moment', 'underscore', 'polyfill' ), '1.10.0', true );
+		wp_register_script( 'hours-loader', plugin_dir_url( __FILE__ ) . '../js/hours-loader.js', array( 'jquery', 'moment', 'underscore' ), '1.10.0', true );
 		wp_enqueue_script( 'hours-loader' );
 
 		// Define expected markup for widget and title containers.

--- a/web/app/plugins/mitlib-pull-hours/src/class-display-widget.php
+++ b/web/app/plugins/mitlib-pull-hours/src/class-display-widget.php
@@ -114,8 +114,7 @@ class Display_Widget extends \WP_Widget {
 		// Register javascript.
 		wp_register_script( 'moment', plugin_dir_url( __FILE__ ) . '../js/libs/moment.min.js', array(), '2.8.3', true );
 		wp_register_script( 'underscore', plugin_dir_url( __FILE__ ) . '../js/libs/underscore.min.js', array(), '1.7.0', true );
-		wp_register_script( 'polyfill', '//polyfill.io/v3/polyfill.js?version=3.52.1', array(), '3.52.1', true );
-		wp_register_script( 'hours-loader', plugin_dir_url( __FILE__ ) . '../js/hours-loader.js', array( 'jquery', 'moment', 'underscore', 'polyfill' ), '1.10.0', true );
+		wp_register_script( 'hours-loader', plugin_dir_url( __FILE__ ) . '../js/hours-loader.js', array( 'jquery', 'moment', 'underscore' ), '1.10.0', true );
 		wp_enqueue_script( 'hours-loader' );
 
 		// Define expected markup for widget and title containers.


### PR DESCRIPTION
This removes the Polyfill javascript library from our hours plugin, and updates the Sentry plugin which also could have loaded the script which is now subject to a supply chain attack.

Confirmation that this works should be that you no longer see the network loading a script from the compromised domain.

## Developer

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

YES dependencies are updated


## Code Reviewer

https://mitlibraries.atlassian.net/browse/PW-99

- [x] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
