### PR TITLE
Add conditional config for the UX tier

### DIFF
--- a/web/wp-config.php
+++ b/web/wp-config.php
@@ -43,6 +43,9 @@ if ( ! empty( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
     case 'dev':
       define( 'DOMAIN_CURRENT_SITE', 'www-dev.libraries.mit.edu' );
       break;
+    case 'www-ux':
+      define( 'DOMAIN_CURRENT_SITE', 'www-ux.libraries.mit.edu' );
+      break;
     case 'lando':
       define( 'DOMAIN_CURRENT_SITE', 'mitlib-wp-network.lndo.site' );
       break;


### PR DESCRIPTION
### Why are these changes being introduced:

We have a long-term multidev for the UX team to use for content work, but it isn't consistently implemented between several names. This causes problems when trying to access the network dashboard and password reset interfaces, because the inconsistent names provoke a server error.

### How does this address that need:

This adds a conditional to web/wp-config.php to standardize how the UX tier is named. This is the same conditional where we assign custom names for the Dev, Test, and Live tiers - so this is a consistent place to assign a custom name for a multidev.

### Document any side effects to this change:

None that I can see - although this is the first time we're using this approach for a multidev, so that may be worth noting.

### Relevant ticket(s):

https://mitlibraries.atlassian.net/browse/pw-92

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] No interfaces are affected by this change.

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
