### PR TITLE
Update composer multidev-search-replace syntax

### DIFF
--- a/scripts/composer/class-mitcomposerscripts.php
+++ b/scripts/composer/class-mitcomposerscripts.php
@@ -61,7 +61,7 @@ class MitComposerScripts {
 	 */
 	public static function multidev_search_replace_syntax( $event ): void {
 		$multidev = self::multidev_name( $event );
-		$terminus_command = "terminus remote:wp mitlib-wp-network.$multidev -- search-replace live-mitlib-wp-network.pantheonsite.io $multidev-mitlib-wp-network.pantheonsite.io --url=live-mitlib-wp-network.pantheonsite.io --network";
+		$terminus_command = "terminus remote:wp mitlib-wp-network.$multidev -- search-replace libraries.mit.edu $multidev-mitlib-wp-network.pantheonsite.io --url=libraries.mit.edu --network";
 		$event->getIO()->write( $terminus_command );
 		$event->getIO()->write( '-----' );
 	}


### PR DESCRIPTION
This updates the way a Composer command operates, making use of our actual domain name rather than the placeholder we used before we launched.

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] There are no secrets affected

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
