### PR TITLE
Remove fake counts from Research & Guides section of libraries homepage

### DIFF
--- a/web/app/themes/mitlib-parent/guide-list.html
+++ b/web/app/themes/mitlib-parent/guide-list.html
@@ -5,7 +5,7 @@
 	<li><a href="http://libguides.mit.edu/country" class="button-secondary--magenta">Country data &amp; analysis</a></li>
 	<li><a href="http://libguides.mit.edu/history" class="button-secondary--magenta">History</a></li>
 	<li><a href="http://libguides.mit.edu/maps" class="button-secondary--magenta">Maps</a></li>
-	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
+	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All guides</a></li>
 </ul>
 <ul class="guide-list-2">
 	<li><a href="http://libguides.mit.edu/bioinfo" class="button-secondary--magenta">Bioinformatics</a></li>
@@ -15,7 +15,7 @@
 	<li><a href="http://libguides.mit.edu/findingimages" class="button-secondary--magenta">Finding images</a></li>
 	<li><a href="http://libguides.mit.edu/envi" class="button-secondary--magenta">Environment</a></li>
 	<li><a href="http://libguides.mit.edu/chemprices" class="button-secondary--magenta">Chemical prices</a></li>
-	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
+	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All guides</a></li>
 </ul>
 <ul class="guide-list-3">
 	<li><a href="http://libguides.mit.edu/eecs" class="button-secondary--magenta">Computer science</a></li>
@@ -24,7 +24,7 @@
 	<li><a href="http://libguides.mit.edu/references" class="button-secondary--magenta">Citation software</a></li>
 	<li><a href="http://libguides.mit.edu/linguistics" class="button-secondary--magenta">Linguistics</a></li>
 	<li><a href="http://libguides.mit.edu/energy" class="button-secondary--magenta">Energy</a></li>
-	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
+	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All guides</a></li>
 </ul>
 <ul class="guide-list-4">
 	<li><a href="http://libguides.mit.edu/gis" class="button-secondary--magenta">Geographic information systems (GIS)</a></li>
@@ -32,7 +32,7 @@
 	<li><a href="http://libguides.mit.edu/patents" class="button-secondary--magenta">Patents</a></li>
 	<li><a href="http://libguides.mit.edu/physics" class="button-secondary--magenta">Physics</a></li>
 	<li><a href="http://libguides.mit.edu/business" class="button-secondary--magenta">Market research</a></li>
-	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
+	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All guides</a></li>
 </ul>
 <ul class="guide-list-5">
 	<li><a href="http://libguides.mit.edu/math" class="button-secondary--magenta">Mathematics</a></li>
@@ -41,7 +41,7 @@
 	<li><a href="/data-management" class="button-secondary--magenta">Data management</a></li>
 	<li><a href="http://libguides.mit.edu/standards" class="button-secondary--magenta">Standards</a></li>
 	<li><a href="http://libguides.mit.edu/ebooks" class="button-secondary--magenta">E-books</a></li>
-	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
+	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All guides</a></li>
 </ul>
 <ul class="guide-list-6">
 	<li><a href="http://libguides.mit.edu/civil" class="button-secondary--magenta">Civil & environmental engineering</a></li>
@@ -49,5 +49,5 @@
 	<li><a href="http://libguides.mit.edu/architect" class="button-secondary--magenta">Architecture & art</a></li>
 	<li><a href="http://libguides.mit.edu/polisci" class="button-secondary--magenta">Political science</a></li>
 	<li><a href="http://libguides.mit.edu/psych" class="button-secondary--magenta">Psychology</a></li>
-	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All 131 guides</a></li>
+	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All guides</a></li>
 </ul>

--- a/web/app/themes/mitlib-parent/js/experts-home.js
+++ b/web/app/themes/mitlib-parent/js/experts-home.js
@@ -76,8 +76,6 @@ function parseExperts(data) {
 	$('.expert .link-profile:eq(1)').attr('href', expertURL2);
 	$('.expert .link-profile:eq(2)').attr('href', expertURL3);
 	$('.expert .link-profile:eq(3)').attr('href', expertURL4);
-	// Add the expert count to the "All Experts" button
-	$('.view-experts .count').text(data.length);
 }
 
 $(function(){

--- a/web/app/themes/mitlib-parent/templates/page-home.php
+++ b/web/app/themes/mitlib-parent/templates/page-home.php
@@ -63,7 +63,7 @@ endif;
 						<li class="expert"></li>
 					</ul>
 				</div>
-				<a href="/experts" class="button-primary--magenta view-experts">All <span class="count">32</span> experts</a>
+				<a href="/experts" class="button-primary--magenta view-experts">All experts</a>
 			</div><!-- end div.guides-experts -->
 		</div><!-- end div.col-2 -->
 	</div><!-- end div.content-main -->


### PR DESCRIPTION
The Research & Guides section of the homepage had fake counts hardcoded into the template. UX asked to remove these counts and change the language to "All guides" and "All experts".

Relevant ticket(s):
PW-105 - https://mitlibraries.atlassian.net/browse/PW-105

How does this address that need:
This PR removes the fake counts and keeps the button text "All x" instead of "All [count] x".

Document any side effects to this change:
None expected.

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
