### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.1', '8.2', '8.3']
+        php-version: ['8.1', '8.2', '8.3', '8.4']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -20,7 +20,7 @@ jobs:
 
     - name: Cache Composer dependencies
       id: composer-cache
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       id: composer-cache
       run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
This makes a few changes to our CI workflow. One is prompted by an imminent retirement, while the others are changes of convenience, given that we're touching the file at all.

The required change is to upgrade our use of actions/cache from v2 to v4. V2 will be retired in a few weeks, so we need to upgrade now or risk not being able to deploy the network. From testing on Github so far, it looks like there are no related changes to this upgrade - our current parameters and arguments continue to work.

The optional changes are:
- Upgrading actions/checkout from v2 to v4 (also the latest available release). We have not been advised about any requirement to make this change.

- Updating the syntax in one of our CI steps to move from `set-output` to a syntax using environment files. This has been showing up in our CI output for a while as a needed change, but Github has been holding off on requiring the change. More details can be found at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

- Adding PHP 8.4 to the list of our tested language versions. We are currently using PHP 8.1 on Pantheon, with no immediate plans to move to 8.4 for a while, but having this output now should be helpful as we plan for the future.

Ticket: https://mitlibraries.atlassian.net/browse/PW-125

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.
- [x] No style changes are included here

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are affected

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] There are no accessibility implications to this change

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
