### PR TITLE
Added new "Citation search" option to the All and Articles tabs of the homepage search box

### DIFF
--- a/web/app/plugins/mitlib-multisearch-widget/templates/tab-all-alma.php
+++ b/web/app/plugins/mitlib-multisearch-widget/templates/tab-all-alma.php
@@ -29,5 +29,5 @@
 	</div>
 </form>
 <p class="also search-all">
-	<a href="/search-advanced/">Advanced search</a>
+	<a href="/search-advanced/">Advanced search</a> | <a href="/citation-search/">Citation search</a>
 </p>

--- a/web/app/plugins/mitlib-multisearch-widget/templates/tab-articles-alma.php
+++ b/web/app/plugins/mitlib-multisearch-widget/templates/tab-articles-alma.php
@@ -71,5 +71,6 @@
 </script>
 <p class="also">Also search for:
 	<a href="/search-journals/">Journals</a> or
-	<a href="/search-databases/">Databases</a>
+	<a href="/search-databases/">Databases</a> or use
+	<a href="/citation-search/">Citation search</a>
 </p>


### PR DESCRIPTION
UXWS requested that we add links to the Primo "Citation Search" option onto the Wordpress homepage search boxes.

This PR adds a "Citation search" link using the new `/citation-search/` shortcut URL to our Wordpress homepage search box on the All and Articles tab.

Confirmed locally and on a multidev, which was reviewed and approved by UXWS.

This work was tracked in https://mitlibraries.atlassian.net/browse/PW-129

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [x] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
