### PR TITLE
Change MIT Analytics plugin to use Matomo Tag Manager instead of core Matomo

### DIFF
--- a/web/app/plugins/mitlib-analytics/mitlib-analytics.php
+++ b/web/app/plugins/mitlib-analytics/mitlib-analytics.php
@@ -22,7 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function mitlib_analytics_init() {
 	// Register a new setting for the Matomo property.
-	register_setting( 'mitlib_analytics', 'mitlib_matomo_property_id' );
 	register_setting( 'mitlib_analytics', 'mitlib_matomo_url' );
 
 	// Register a section for libraries settings on the mitlib-analytics page.
@@ -33,23 +32,10 @@ function mitlib_analytics_init() {
 		'mitlib-analytics'
 	);
 
-	// Register a new field in the "mitlib_analytics_general" section, inside the "mitlib-analytics" page.
-	add_settings_field(
-		'mitlib_matomo_property_id',
-		__( 'Matomo Analytics Property ID', 'mitlib_analytics' ),
-		'mitlib\mitlib_analytics_property_callback',
-		'mitlib-analytics',
-		'mitlib_analytics_general',
-		array(
-			'label_for' => 'mitlib_matomo_property_id',
-			'class' => 'mitlib_analytics_row',
-		)
-	);
-
 	// Register the domain list field in the "mitlib_analytics_general" section, inside the "mitlib-analytics" page.
 	add_settings_field(
 		'mitlib_matomo_url',
-		__( 'Matomo URL', 'mitlib_analytics' ),
+		__( 'Matomo Tag Manager URL', 'mitlib_analytics' ),
 		'mitlib\mitlib_analytics_url_callback',
 		'mitlib-analytics',
 		'mitlib_analytics_general',
@@ -80,24 +66,7 @@ add_action( 'network_admin_menu', 'mitlib\mitlib_analytics_menu' );
  */
 function mitlib_analytics_section_libraries() {
 	?>
-	<p>These settings control the Libraries-level analytics information.</p>
-	<?php
-}
-
-/**
- * Field rendering callback: Matomo property
- */
-function mitlib_analytics_property_callback() {
-	// Get the settings value.
-	$options = get_site_option( 'mitlib_matomo_property_id' );
-	?>
-	<input
-		type="text"
-		name="<?php echo esc_attr( 'mitlib_matomo_property_id' ); ?>"
-		value="<?php echo esc_attr( $options ); ?>"
-		id="<?php echo esc_attr( 'mitlib_matomo_property_id' ); ?>"
-		size="20">
-	<p>If you aren't sure what value to use, please contact UX/Web Services.</p>
+	<p>These settings control the Libraries-level analytics information. They implement a Matomo Tag Manager container across all network sites.</p>
 	<?php
 }
 
@@ -138,21 +107,13 @@ function mitlib_analytics_page_html() {
 		// Update settings.
 		if ( 'update' == filter_input( INPUT_POST, 'action' ) ) {
 			// Set default values.
-			$mitlib_matomo_property_id = '';
 			$mitlib_matomo_url = '';
-			// Matomo property ID.
-			if ( filter_input( INPUT_POST, 'mitlib_matomo_property_id' ) ) {
-				$mitlib_matomo_property_id = sanitize_text_field(
-					wp_unslash( filter_input( INPUT_POST, 'mitlib_matomo_property_id' ) )
-				);
-			}
 			// Matomo URL.
 			if ( filter_input( INPUT_POST, 'mitlib_matomo_url' ) ) {
 				$mitlib_matomo_url = sanitize_text_field(
 					wp_unslash( filter_input( INPUT_POST, 'mitlib_matomo_url' ) )
 				);
 			}
-			update_site_option( 'mitlib_matomo_property_id', $mitlib_matomo_property_id );
 			update_site_option( 'mitlib_matomo_url', $mitlib_matomo_url );
 		}
 	}

--- a/web/app/plugins/mitlib-analytics/mitlib-analytics.php
+++ b/web/app/plugins/mitlib-analytics/mitlib-analytics.php
@@ -114,8 +114,8 @@ function mitlib_analytics_url_callback() {
 		value="<?php echo esc_attr( $options ); ?>"
 		id="<?php echo esc_attr( 'mitlib_matomo_url' ); ?>"
 		size="60">
-	<p>The base URL for the Matomo instance to which analytics will be reported, including trailing forward-slash.</p>
-  <p>E.g., <pre>https://matomo.example.org/</pre></p>
+	<p>The base URL for the Matomo Tag Manager instance to which analytics will be reported. The URL must contain the container id.</p>
+  <p>E.g., <pre>https://matomo.mitlibrary.net/js/container_12345678.js</pre></p>
 	<?php
 }
 
@@ -178,23 +178,20 @@ function mitlib_analytics_page_html() {
 }
 
 /**
- * View function that outputs the Matomo code on public pages.
+ * View function that outputs the Matomo Tag Manager code into the header of all pages
  */
-function mitlib_analytics_view() {
-	echo "<!-- Matomo -->
-  <script>
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like 'setCustomDimension' should be called before 'trackPageView' */
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u='" . esc_html( get_site_option( 'mitlib_matomo_url' ) ) . "';
-      _paq.push(['setTrackerUrl', u+'matomo.php']);
-      _paq.push(['setSiteId', '" . esc_html( get_site_option( 'mitlib_matomo_property_id' ) ) . "']);
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
-  </script>
-  <!-- End Matomo Code -->";
+
+function mitlib_analytics_tag_manager_view() {
+	echo "
+	<!-- Matomo Tag Manager -->
+<script>
+  var _mtm = window._mtm = window._mtm || [];
+  _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+  (function() {
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.async=true; g.src='" . esc_html( get_site_option( 'mitlib_matomo_url' ) ) . "'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<!-- End Matomo Tag Manager -->";
 }
-add_action( 'wp_footer', 'mitlib\mitlib_analytics_view' );
+add_action( 'wp_head', 'mitlib\mitlib_analytics_tag_manager_view' );

--- a/web/app/plugins/mitlib-analytics/mitlib-analytics.php
+++ b/web/app/plugins/mitlib-analytics/mitlib-analytics.php
@@ -141,7 +141,6 @@ function mitlib_analytics_page_html() {
 /**
  * View function that outputs the Matomo Tag Manager code into the header of all pages
  */
-
 function mitlib_analytics_tag_manager_view() {
 	echo "
 	<!-- Matomo Tag Manager -->


### PR DESCRIPTION
## Developer
As part of work being done on UXWS to improve our analytics tracking, the UX team is aiming to use Tag Manager to be able to add new metrics to track without technical support.

This work updates our MIT Analytics plugin to use Matomo Tag Manager instead of the core Matomo tracking code, which is the recommended setup instead of having both coexist.
* Removed the property ID field
* Changed the Matomo URL field to use the structure of the Tag Manager snippet.

Note: The current setup only supports a single container's URL at the moment. If we want to support multiple Tag Manager containers we'd need to rework this implementation.

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [X] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [x] The documentation has been updated or is unnecessary
- [x] New dependencies are appropriate or there were no changes
