### PR TITLE
Experiment with alert cache busting

### DIFF
--- a/web/app/themes/mitlib-parent/js/alerts.js
+++ b/web/app/themes/mitlib-parent/js/alerts.js
@@ -119,7 +119,7 @@ $(function(){
 
 	// This retrieves a list of posts, with additional parsing to determine if
 	// any are displayable alerts.
-	$.getJSON('/wp-json/wp/v2/posts')
+	$.getJSON('/wp-json/wp/v2/posts', {_: new Date().getTime()})
 		.done(function(data){
 			showAlerts(data);
 		});


### PR DESCRIPTION
This adds a timestamp to the querystring of the call to the WordPress API, causing the user's browser to avoid using its internal cache and actually re-load the API.

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
