### PR TITLE
Remove "Citation Software" guide from homepage guides rotation

### DIFF
--- a/web/app/themes/mitlib-parent/guide-list.html
+++ b/web/app/themes/mitlib-parent/guide-list.html
@@ -21,7 +21,6 @@
 	<li><a href="http://libguides.mit.edu/eecs" class="button-secondary--magenta">Computer science</a></li>
 	<li><a href="http://libguides.mit.edu/chemeng" class="button-secondary--magenta">Chemical engineering</a></li>
 	<li><a href="http://libguides.mit.edu/finance" class="button-secondary--magenta">Finance &amp; investment</a></li>
-	<li><a href="http://libguides.mit.edu/references" class="button-secondary--magenta">Citation software</a></li>
 	<li><a href="http://libguides.mit.edu/linguistics" class="button-secondary--magenta">Linguistics</a></li>
 	<li><a href="http://libguides.mit.edu/energy" class="button-secondary--magenta">Energy</a></li>
 	<li><a href="/experts" class="button-primary--magenta border inline all-guides">All guides</a></li>


### PR DESCRIPTION
## Developer

We discovered that the guide for Citation Software was no longer available, and the link is broken. To remedy this we decided to remove the link to that guide from the rotation of expert guides available on the homepage.

This work removes that guide from the group that included it.

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
