### PR TITLE
Add underlines to links in the body of news stories

### DIFF
--- a/web/app/themes/mitlib-child/inc/content-front.php
+++ b/web/app/themes/mitlib-child/inc/content-front.php
@@ -36,15 +36,16 @@ if ( count( $sticky ) > 0 ) {
 			$the_query->the_post();
 			?>
 
-		<div class="excerpt-post">
+		<aside aria-label="Featured content" class="mitlib-spotlight">
 			<?php if ( get_first_post_image() ) : ?>
-			<img class="excerpt-post__fig" src="<?php echo esc_attr( get_first_post_image() ); ?>" width="200" >
+				<img src="<?php echo esc_attr( get_first_post_image() ); ?>">
 			<?php endif; ?>
-			<div class="excerpt-post__body">
+			<div>				
 				<h3><a href="<?php echo esc_url( the_permalink() ); ?>"><?php the_title(); ?></a></h3>
 				<?php custom_excerpt( 20, '...' ); ?>
-			</div>
-		</div>
+				<a class="btn btn-secondary" href="<?php echo esc_url( the_permalink() ); ?>">Read more</a>			
+			</div>			
+		</aside>
 
 			<?php
 		endwhile;

--- a/web/app/themes/mitlib-child/inc/content-front.php
+++ b/web/app/themes/mitlib-child/inc/content-front.php
@@ -43,7 +43,7 @@ if ( count( $sticky ) > 0 ) {
 			<div>				
 				<h3><?php the_title(); ?></h3>
 				<?php custom_excerpt( 20, '...' ); ?>
-				<a class="btn btn-secondary" aria-label="Read more about <?php the_title(); ?>" href="<?php echo esc_url( the_permalink() ); ?>">Read more</a>			
+				<a class="btn btn-secondary" title="Read more about <?php the_title(); ?>" href="<?php echo esc_url( the_permalink() ); ?>">Read more</a>			
 			</div>			
 		</aside>
 

--- a/web/app/themes/mitlib-child/inc/content-front.php
+++ b/web/app/themes/mitlib-child/inc/content-front.php
@@ -43,7 +43,7 @@ if ( count( $sticky ) > 0 ) {
 			<div>				
 				<h3><a href="<?php echo esc_url( the_permalink() ); ?>"><?php the_title(); ?></a></h3>
 				<?php custom_excerpt( 20, '...' ); ?>
-				<a class="btn btn-secondary" href="<?php echo esc_url( the_permalink() ); ?>">Read more</a>			
+				<a class="btn btn-secondary" aria-label="Read more about <?php the_title(); ?>" href="<?php echo esc_url( the_permalink() ); ?>">Read more</a>			
 			</div>			
 		</aside>
 

--- a/web/app/themes/mitlib-child/inc/content-front.php
+++ b/web/app/themes/mitlib-child/inc/content-front.php
@@ -41,7 +41,7 @@ if ( count( $sticky ) > 0 ) {
 				<img src="<?php echo esc_attr( get_first_post_image() ); ?>">
 			<?php endif; ?>
 			<div>				
-				<h3><a href="<?php echo esc_url( the_permalink() ); ?>"><?php the_title(); ?></a></h3>
+				<h3><?php the_title(); ?></h3>
 				<?php custom_excerpt( 20, '...' ); ?>
 				<a class="btn btn-secondary" aria-label="Read more about <?php the_title(); ?>" href="<?php echo esc_url( the_permalink() ); ?>">Read more</a>			
 			</div>			

--- a/web/app/themes/mitlib-news/style.css
+++ b/web/app/themes/mitlib-news/style.css
@@ -11,7 +11,7 @@ Template: mitlib-parent
 .content-area a:link, 
 .content-area a:visited {
 	color: #000;
-	text-decoration: none;
+	text-decoration: underline;
 }
 .content-area a:hover, 
 .content-area a:active {

--- a/web/app/themes/mitlib-news/style.css
+++ b/web/app/themes/mitlib-news/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib News
 Author: MIT Libraries
-Version: 0.5
+Version: 0.6
 Description: A child theme of the MIT Libraries' parent, focused on News features and content.
 Template: mitlib-parent
 

--- a/web/app/themes/mitlib-parent/css/scss/modules/_colors.scss
+++ b/web/app/themes/mitlib-parent/css/scss/modules/_colors.scss
@@ -149,6 +149,7 @@ $color-guides-experts: $magenta-dark;
 // Adding new color values until we can adjust the global variables above
 $info-blue: #007499;
 $success-green: #009900;
+$spotlight-purple: #990099;
 
 $info-border-color: $info-blue;
 $info-icon-color: $info-blue;
@@ -161,3 +162,5 @@ $danger-icon-color: $red;
 
 $success-border-color: $success-green;
 $success-icon-color: $success-green;
+
+$spotlight-border-color: $spotlight-purple;

--- a/web/app/themes/mitlib-parent/css/scss/partials/_alerts.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_alerts.scss
@@ -185,7 +185,7 @@
 
 	img {
 		width: 100%;
-		max-width: 240px;
+		max-width: 180px;
 		min-width: 100px;
 		height: 100%;
 	}

--- a/web/app/themes/mitlib-parent/css/scss/partials/_alerts.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_alerts.scss
@@ -185,7 +185,7 @@
 
 	img {
 		width: 100%;
-		max-width: 180px;
+		max-width: 170px;
 		min-width: 100px;
 		height: 100%;
 	}

--- a/web/app/themes/mitlib-parent/css/scss/partials/_alerts.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_alerts.scss
@@ -98,13 +98,13 @@
 	}
 }
 
-.mitlib-alert {
+.mitlib-alert, .mitlib-spotlight {
 	border: 4px solid $info-border-color;
 	margin-bottom: 20px;
 	padding: 16px;
 	display: flex;
 
-	i  {
+	> i  {
 		margin-right: 12px;
 
 		&:before{
@@ -124,14 +124,13 @@
 	}
 
 	div > h3 {
-		font-weight: 700;
+		font-weight: 600;
 		margin-top: 2px;
+		font-size: 1.25rem;
 	}
 
 	p {
-		margin-bottom: 16px;
-
-		&:last-of-type {margin-bottom: 0 !important;}
+		margin-bottom: 16px;		
 	}
 
 	.btn {
@@ -173,5 +172,25 @@
 			color: $success-icon-color;
 			content: "\f00c";
 		}
+	}
+}
+
+.mitlib-alert {
+	p:last-of-type {margin-bottom: 0 !important;}
+}
+
+.mitlib-spotlight {
+	border-color: $spotlight-border-color;
+	column-gap: 24px;
+
+	img {
+		width: 100%;
+		max-width: 240px;
+		min-width: 100px;
+		height: 100%;
+	}
+
+	p {
+		padding-bottom: 4px;
 	}
 }

--- a/web/app/themes/mitlib-parent/style.css
+++ b/web/app/themes/mitlib-parent/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib Parent
 Author: MIT Libraries
-Version: 0.7
+Version: 0.8
 Description: The parent theme for the MIT Libraries' Pentagram-designed identity.
 
 */


### PR DESCRIPTION
## Developer
As part of the work done to change the typeface from Open Sans to Neue Haas Grotesk, the underline to links in news stories was removed. Since no other affordance was added, it's impossible to tell at a glance that there are links to visit.

This work adds that underline back in.

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
