### PR TITLE
Add underlines to links in the body of news stories

### DIFF
--- a/web/app/themes/mitlib-news/style.css
+++ b/web/app/themes/mitlib-news/style.css
@@ -11,7 +11,7 @@ Template: mitlib-parent
 .content-area a:link, 
 .content-area a:visited {
 	color: #000;
-	text-decoration: none;
+	text-decoration: underline;
 }
 .content-area a:hover, 
 .content-area a:active {

--- a/web/app/themes/mitlib-news/style.css
+++ b/web/app/themes/mitlib-news/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib News
 Author: MIT Libraries
-Version: 0.5
+Version: 0.6
 Description: A child theme of the MIT Libraries' parent, focused on News features and content.
 Template: mitlib-parent
 


### PR DESCRIPTION
## Developer
As part of the work done to change the typeface from Open Sans to Neue Haas Grotesk, the underline to links in news stories was removed. Since no other affordance was added, it's impossible to tell at a glance that there are links to visit.

This work adds that underline back in.

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
