### PR TITLE
Adding wp_bulk_delete plugin to bulk delete old news posts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,6 +120,7 @@
     "wpackagist-plugin/widget-css-classes": "1.5.4.1",
     "wpackagist-plugin/widget-importer-exporter": "^1.6",
     "wpackagist-plugin/wordpress-importer": "^0.8.0",
+    "wpackagist-plugin/wp-bulk-delete": "^1.3",
     "wpackagist-plugin/wp-mail-smtp": "^4.0",
     "wpackagist-plugin/wp-native-php-sessions": "*",
     "wpackagist-plugin/wp-security-audit-log": "^5.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "37eb7a6351d37e20647698c6683ccf59",
+    "content-hash": "ad12b68caa4cbca755b590c98898fa06",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -3041,6 +3041,24 @@
             "homepage": "https://wordpress.org/plugins/wordpress-importer/"
         },
         {
+            "name": "wpackagist-plugin/wp-bulk-delete",
+            "version": "1.3.7",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-bulk-delete/",
+                "reference": "tags/1.3.7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-bulk-delete.1.3.7.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-bulk-delete/"
+        },
+        {
             "name": "wpackagist-plugin/wp-mail-smtp",
             "version": "4.5.0",
             "source": {
@@ -4541,6 +4559,6 @@
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -75,6 +75,7 @@
   <exclude-pattern>web/app/plugins/widget-css-classes</exclude-pattern>
   <exclude-pattern>web/app/plugins/widget-importer-exporter</exclude-pattern>
   <exclude-pattern>web/app/plugins/wordpress-importer</exclude-pattern>
+  <exclude-pattern>web/app/plugins/wp-bulk-delete</exclude-pattern>
   <exclude-pattern>web/app/plugins/wp-mail-smtp</exclude-pattern>
   <exclude-pattern>web/app/plugins/wp-native-php-sessions</exclude-pattern>
   <exclude-pattern>web/app/plugins/WP-SCSS</exclude-pattern>


### PR DESCRIPTION
## Developer
We had a request to remove all news stories (across all post types) older than July 1, 2021. To explore this, we added this plugin to a multidev to experiment with it's functionality. We found the results satisfactory, and would like to move it to production.

This work introduces the wp_bulk_delete plugin to our Wordpress site.

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
