### PR TITLE
Adding temporary USE callout banner to library homepage

### DIFF
--- a/web/app/themes/mitlib-parent/css/scss/partials/_alerts.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_alerts.scss
@@ -98,6 +98,7 @@
 	}
 }
 
+// New contextual alert and spotlight styles
 .mitlib-alert, .mitlib-spotlight {
 	border: 4px solid $info-border-color;
 	margin-bottom: 20px;
@@ -192,5 +193,36 @@
 
 	p {
 		padding-bottom: 4px;
+	}
+}
+
+// Full page banner styles
+div.mitlib-banner {
+	background-color: #007899;
+	padding: 20px 32px;
+	display: flex;
+	justify-content: center;
+
+	div.wrap-notice {
+		max-width: 1024px;
+    width: 100%;
+	}
+
+	h1 {
+		font-size: 1.2rem;
+		color: #e5f9ff;
+		padding: 0;
+		margin-bottom: 0;
+	}
+
+	a {
+		text-decoration: underline;
+		text-underline-offset: 0.3rem;
+		text-decoration-color: #00c8ff;
+		color: #fff;
+	}
+
+	a:hover {
+		text-decoration-color: #99E9FF;
 	}
 }

--- a/web/app/themes/mitlib-parent/header.php
+++ b/web/app/themes/mitlib-parent/header.php
@@ -41,6 +41,16 @@ if ( 'slim' === get_option( 'menu_style_setting' ) ) {
 
 <body <?php body_class(); ?>>
 	<div id="skip"><a href="#content">Skip to Main Content</a></div>
+
+	<?php
+	// Get page ID
+	$page_id = get_queried_object_id();
+
+	// If this is the homepage, show the temporary USE banner
+	if ($page_id == 122) {
+		get_template_part( 'inc/banner' );
+	}	?>
+
 	<div class="wrap-page">
 		<header class="header-main flex-container flex-end">
 			<?php if ( 'full' === $menu ) { ?>

--- a/web/app/themes/mitlib-parent/inc/banner.php
+++ b/web/app/themes/mitlib-parent/inc/banner.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * Template for USE Homepage Banner
+ *
+ * @package MITlib_Parent
+ * @since 0.2.0
+ */
+
+namespace Mitlib\Parent;
+
+?>
+<div class="mitlib-banner info">
+	<div class="wrap-notice">
+		<h1 class="title"><a href="https://search.libraries.mit.edu">Try our new search</a> before it launches this summer!</div></h1>
+	</div>
+</div>

--- a/web/app/themes/mitlib-parent/inc/banner.php
+++ b/web/app/themes/mitlib-parent/inc/banner.php
@@ -11,6 +11,6 @@ namespace Mitlib\Parent;
 ?>
 <div class="mitlib-banner info">
 	<div class="wrap-notice">
-		<h1 class="title"><a href="https://search.libraries.mit.edu">Try our new search</a> before it launches this summer!</div></h1>
+		<h1><a href="https://search.libraries.mit.edu">Try our new search</a> before it launches this summer!</div></h1>
 	</div>
 </div>

--- a/web/app/themes/mitlib-parent/style.css
+++ b/web/app/themes/mitlib-parent/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib Parent
 Author: MIT Libraries
-Version: 0.8
+Version: 0.9
 Description: The parent theme for the MIT Libraries' Pentagram-designed identity.
 
 */

--- a/web/app/themes/mitlib-parent/style.css
+++ b/web/app/themes/mitlib-parent/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib Parent
 Author: MIT Libraries
-Version: 0.9
+Version: 0.10
 Description: The parent theme for the MIT Libraries' Pentagram-designed identity.
 
 */


### PR DESCRIPTION
## Developer
As part of https://mitlibraries.atlassian.net/browse/USE-446 we wanted to prepare a banner to direct people to USE. This work implements a temporary banner that's hardcoded to appear ONLY on the homepage.

This work does not attempt to restyle our site-wide alerts or build this in a modular, reusable way. Because of this, the style for this is hardcoded hex values instead of introducing a new variable system. This work will be considered when we implement the new homepage.

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
