### PR TITLE
PW-183: Barker Library homepage and location page overrides

### DIFF
--- a/web/app/mu-plugins/mitlib-post/data/location/group_58e22931ab9f5.json
+++ b/web/app/mu-plugins/mitlib-post/data/location/group_58e22931ab9f5.json
@@ -101,6 +101,25 @@
             "ui_off_text": ""
         },
         {
+            "key": "field_49",
+            "label": "Unstaffed Location",
+            "name": "unstaffed_location",
+            "type": "true_false",
+            "instructions": "Is this an unstaffed location? If checked, we'll hide the phone number and one of the tabs on the location page.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },        
+        {
             "key": "field_30",
             "label": "Study Location",
             "name": "study_location",

--- a/web/app/plugins/mitlib-pull-hours/templates/display-widget-frontpage.php
+++ b/web/app/plugins/mitlib-pull-hours/templates/display-widget-frontpage.php
@@ -11,17 +11,17 @@
 <div class="location">
 	<a href="/barker" aria-labelledby="barker" class="img-loc barker"><span class="sr" id="barker">Barker Library</span></a>
 	<div class="wrap-loc-info">
-		<h3><a class="name-location" href="/barker">Barker Library</a></h3><div class="hours"><span data-location-hours="Barker Library"></span> today</div><div class="location-info"><a href="/locations/#!barker-library" class="map-location">10-500</a></div>
+		<h3><a class="name-location" href="/barker">Barker Library</a></h3><div class="hours"><span data-location-hours="Barker Library"></span> today</div><div class="location-info"><a href="/locations/#!barker-library" class="map-location">10-500</a><?php if ( get_field("unstaffed_location", 322) == false ) : ?><a href="tel:617-253-0968" class="phone"><span class="number">617-253-0968</span></a><?php endif; ?></div>
 	</div>
 </div>
-<?php
+<?php	
 	// Load location alerts for Barker (post 322).
 	$this->location_alert( 322 );
 ?>
 <div class="location">
 	<a href="/dewey" aria-labelledby="dewey" class="img-loc dewey"><span class="sr" id="dewey">Dewey Library</span></a>
 	<div class="wrap-loc-info">
-		<h3><a class="name-location" href="/dewey">Dewey Library</a></h3><div class="hours"><span data-location-hours="Dewey Library"></span> today</div><div class="location-info"><a href="/locations/#!dewey-library" class="map-location">E53-100</a><a href="tel:617-253-5676" class="phone"><span class="number">617-253-5676</span></a></div>
+		<h3><a class="name-location" href="/dewey">Dewey Library</a></h3><div class="hours"><span data-location-hours="Dewey Library"></span> today</div><div class="location-info"><a href="/locations/#!dewey-library" class="map-location">E53-100</a><?php if ( get_field("unstaffed_location", 313) == false ) : ?><a href="tel:617-253-5676" class="phone"><span class="number">617-253-5676</span></a><?php endif; ?></div>
 	</div>
 </div>
 <?php
@@ -31,7 +31,7 @@
 <div class="location">
 	<a href="/hayden" aria-labelledby="hayden" class="img-loc hayden"><span class="sr" id="hayden">Hayden Library</span></a>
 	<div class="wrap-loc-info">
-		<h3><a class="name-location" href="/hayden">Hayden Library</a></h3><div class="hours"><span data-location-hours="Hayden Library"></span> today</div> <div class="location-info"><a href="/locations/#!hayden-library" class="map-location">14S-100</a><a href="tel:617-253-5671" class="phone"><span class="number">617-253-5671</span></a></div>
+		<h3><a class="name-location" href="/hayden">Hayden Library</a></h3><div class="hours"><span data-location-hours="Hayden Library"></span> today</div> <div class="location-info"><a href="/locations/#!hayden-library" class="map-location">14S-100</a><?php if ( get_field("unstaffed_location", 452) == false ) : ?><a href="tel:617-253-5671" class="phone"><span class="number">617-253-5671</span></a><?php endif; ?></div>
 	</div>
 </div>
 <?php
@@ -44,7 +44,7 @@
 <div class="location hidden-mobile inactive-mobile">
 	<a href="/rotch" aria-labelledby="rotch" class="img-loc rotch"><span class="sr" id="rotch">Rotch Library</span></a>
 	<div class="wrap-loc-info">
-		<h3><a class="name-location" href="/rotch">Rotch Library</a></h3><div class="hours"><span data-location-hours="Rotch Library"></span> today</div><div class="location-info"><a href="/locations/#!rotch-library" class="map-location">7-238</a><a href="tel:617-258-5592" class="phone"><span class="number">617-258-5592</span></a></div>
+		<h3><a class="name-location" href="/rotch">Rotch Library</a></h3><div class="hours"><span data-location-hours="Rotch Library"></span> today</div><div class="location-info"><a href="/locations/#!rotch-library" class="map-location">7-238</a><?php if ( get_field("unstaffed_location", 359) == false ) : ?><a href="tel:617-258-5592" class="phone"><span class="number">617-258-5592</span></a><?php endif; ?></div>
 	</div>
 </div>
 <?php
@@ -54,7 +54,7 @@
 <div class="location hidden-mobile inactive-mobile">
 	<a href="/distinctive-collections" aria-labelledby="dc" class="img-loc archives"><span class="sr" id="dc">Distinctive Collections Reading Room</span></a>
 	<div class="wrap-loc-info">
-		<h3><a class="name-location" href="/distinctive-collections">Distinctive Collections Reading Room</a></h3><div class="hours"><span data-location-hours="Distinctive Collections"></span> today</div><div class="location-info"><a href="/locations/#!distinctive-collections" class="map-location">14N-118</a><a href="tel:617-253-5690" class="phone"><span class="number">617-253-5690</span></a></div>
+		<h3><a class="name-location" href="/distinctive-collections">Distinctive Collections Reading Room</a></h3><div class="hours"><span data-location-hours="Distinctive Collections"></span> today</div><div class="location-info"><a href="/locations/#!distinctive-collections" class="map-location">14N-118</a><?php if ( get_field("unstaffed_location", 504) == false ) : ?><a href="tel:617-253-5690" class="phone"><span class="number">617-253-5690</span></a><?php endif; ?></div>
 	</div>
 </div>
 <?php
@@ -64,7 +64,7 @@
 <div class="location hidden-mobile inactive-mobile">
 	<a href="/music" aria-labelledby="lewis" class="img-loc lewis"><span class="sr" id="lewis">Lewis Music Library</span></a>
 	<div class="wrap-loc-info">
-		<h3><a class="name-location" href="/music">Lewis Music Library</a></h3><div class="hours"><span data-location-hours="Lewis Music Library"></span> today</div><div class="location-info"><a href="/locations/#!lewis-music-library" class="map-location">14E-109</a><a href="tel:617-253-5689" class="phone"><span class="number">617-253-5689</span></a></div>
+		<h3><a class="name-location" href="/music">Lewis Music Library</a></h3><div class="hours"><span data-location-hours="Lewis Music Library"></span> today</div><div class="location-info"><a href="/locations/#!lewis-music-library" class="map-location">14E-109</a><?php if ( get_field("unstaffed_location", 473) == false ) : ?><a href="tel:617-253-5689" class="phone"><span class="number">617-253-5689</span></a><?php endif; ?></div>
 	</div>
 </div>
 <?php

--- a/web/app/plugins/mitlib-pull-hours/templates/display-widget-frontpage.php
+++ b/web/app/plugins/mitlib-pull-hours/templates/display-widget-frontpage.php
@@ -11,7 +11,7 @@
 <div class="location">
 	<a href="/barker" aria-labelledby="barker" class="img-loc barker"><span class="sr" id="barker">Barker Library</span></a>
 	<div class="wrap-loc-info">
-		<h3><a class="name-location" href="/barker">Barker Library</a></h3><div class="hours"><span data-location-hours="Barker Library"></span> today</div><div class="location-info"><a href="/locations/#!barker-library" class="map-location">10-500</a><a href="tel:617-253-0968" class="phone"><span class="number">617-253-0968</span></a></div>
+		<h3><a class="name-location" href="/barker">Barker Library</a></h3><div class="hours"><span data-location-hours="Barker Library"></span> today</div><div class="location-info"><a href="/locations/#!barker-library" class="map-location">10-500</a></div>
 	</div>
 </div>
 <?php

--- a/web/app/themes/mitlib-parent/css/scss/partials/_alerts.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_alerts.scss
@@ -133,6 +133,18 @@
 		margin-bottom: 16px;		
 	}
 
+	a {
+		color: inherit;
+		font-weight: 500;
+		text-decoration: underline;
+		text-decoration-color: #0000FF;
+		text-underline-offset: 0.25rem;  
+
+		&:hover {
+			color: #0000FF;
+		}
+	}
+
 	.btn {
 		border: 1px solid $black;
 		border-radius: 0;

--- a/web/app/themes/mitlib-parent/css/scss/partials/_locations.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_locations.scss
@@ -83,7 +83,7 @@
 			}
 }
 
-// Overrides to Barker page styles for closure
+// When unstaffed class is added to location pages, style the first tab like the second
 #content.unstaffed {
 	.tab.tab1 {
 		.first {

--- a/web/app/themes/mitlib-parent/css/scss/partials/_locations.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_locations.scss
@@ -84,7 +84,7 @@
 }
 
 // Overrides to Barker page styles for closure
-body.locationPage.page-barker {
+#content.unstaffed {
 	.tab.tab1 {
 		.first {
 			width: 20%;

--- a/web/app/themes/mitlib-parent/css/scss/partials/_locations.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_locations.scss
@@ -92,9 +92,11 @@ body.locationPage.page-barker {
 		.second {
 			width: 80%;
 			}
-	ul.with-bullets li {
+	ul li {
 			list-style: disc;
 			margin-left: 20px;
+
+			ul li {list-style: circle;}
 			}
 	}
 }

--- a/web/app/themes/mitlib-parent/css/scss/partials/_locations.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_locations.scss
@@ -83,6 +83,7 @@
 			}
 }
 
+// Overrides to Barker page styles for closure
 body.locationPage.page-barker {
 	.tab.tab1 {
 		.first {
@@ -90,6 +91,10 @@ body.locationPage.page-barker {
 		}
 		.second {
 			width: 80%;
+			}
+	ul.with-bullets li {
+			list-style: disc;
+			margin-left: 20px;
 			}
 	}
 }

--- a/web/app/themes/mitlib-parent/css/scss/partials/_locations.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_locations.scss
@@ -83,6 +83,17 @@
 			}
 }
 
+body.locationPage.page-barker {
+	.tab.tab1 {
+		.first {
+			width: 20%;
+		}
+		.second {
+			width: 80%;
+			}
+	}
+}
+
 // The 2021 location template adjusts column widths because the sidebar is not
 // loaded.
 .locationPage.page-template-page-location-2021 {

--- a/web/app/themes/mitlib-parent/inc/content-location.php
+++ b/web/app/themes/mitlib-parent/inc/content-location.php
@@ -131,7 +131,7 @@ $alert_title = cf( 'alert_title' );
 				<?php } else { ?>
 					<div class="hours-today">
 						<span>Today's hours: <strong data-location-hours="<?php the_title(); ?>"></strong></span>
-						<?php if ( true === $study24 ) : ?>
+						<?php if ( true === $study24 && get_the_ID() != 322) : ?><!-- Added conditional to override this display for Barker -->
 							| <a class="study-24-7" href="<?php echo esc_url( $gStudy24Url ); ?>" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>
 						<?php endif; ?>
 						<a href="/hours" class="link-hours-all">See all hours <i class="fa fa-arrow-right"></i></a>

--- a/web/app/themes/mitlib-parent/inc/content-location.php
+++ b/web/app/themes/mitlib-parent/inc/content-location.php
@@ -110,7 +110,9 @@ $alert_title = cf( 'alert_title' );
 						<span class="subject-library"><?php echo esc_html( $subject ); ?></span>
 					</h1>
 					<div class="info-more">
+							<?php if ( $phone ) : ?>
 						<a href="tel:<?php echo esc_url( $phone ); ?>" class="phone"><?php echo esc_html( $phone ); ?></a> |
+							<?php endif; ?>
 							<?php if ( $email ) : ?>
 						<a href="mailto:<?php echo esc_url( $email ); ?>" class="email"><?php echo esc_html( $email ); ?></a> |
 							<?php endif; ?>

--- a/web/app/themes/mitlib-parent/inc/content-location.php
+++ b/web/app/themes/mitlib-parent/inc/content-location.php
@@ -23,6 +23,8 @@ namespace Mitlib\Parent;
 	// $equipment = cf("equipment");
 	$arexpert = get_field( 'expert' );
 
+	$unstaffed_location = get_field( 'unstaffed_location' );
+
 	$title1 = cf( 'tab_1_title' );
 	$subtitle1 = cf( 'tab_1_subtitle' );
 	$content1left = get_field( 'tab_1_content_left' );
@@ -110,7 +112,7 @@ $alert_title = cf( 'alert_title' );
 						<span class="subject-library"><?php echo esc_html( $subject ); ?></span>
 					</h1>
 					<div class="info-more">
-							<?php if ( $phone ) : ?>
+							<?php if ( $phone && !$unstaffed_location ) : ?>
 						<a href="tel:<?php echo esc_url( $phone ); ?>" class="phone"><?php echo esc_html( $phone ); ?></a> |
 							<?php endif; ?>
 							<?php if ( $email ) : ?>
@@ -131,7 +133,7 @@ $alert_title = cf( 'alert_title' );
 				<?php } else { ?>
 					<div class="hours-today">
 						<span>Today's hours: <strong data-location-hours="<?php the_title(); ?>"></strong></span>
-						<?php if ( true === $study24 && get_the_ID() != 322) : ?><!-- Added conditional to override this display for Barker -->
+						<?php if ( true === $study24 && !$unstaffed_location) : ?><!-- Added conditional to override this display for Barker -->
 							| <a class="study-24-7" href="<?php echo esc_url( $gStudy24Url ); ?>" alt="This location contains one or more study spaces available 24 hours a day, seven days a week. Click the link for more info." title="Study 24/7">Study 24/7</a>
 						<?php endif; ?>
 						<a href="/hours" class="link-hours-all">See all hours <i class="fa fa-arrow-right"></i></a>
@@ -153,7 +155,7 @@ $alert_title = cf( 'alert_title' );
 		<!-- </div> end div.flex-item -->
 	</div><!-- end div.libraryTitle -->
 
-	<div id="content" class="content <?php echo esc_attr( $strLocation ); ?> has-sidebar">
+	<div id="content" class="content <?php echo esc_attr( $strLocation ); ?> has-sidebar <?php if ($unstaffed_location) { echo "unstaffed"; } ?>">
 		<div class="main-content content-main">
 
 			<?php

--- a/web/app/themes/mitlib-parent/style.css
+++ b/web/app/themes/mitlib-parent/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib Parent
 Author: MIT Libraries
-Version: 0.8
+Version: 0.9
 Description: The parent theme for the MIT Libraries' Pentagram-designed identity.
 
 */

--- a/web/app/themes/mitlib-parent/templates/page-hours.php
+++ b/web/app/themes/mitlib-parent/templates/page-hours.php
@@ -232,8 +232,11 @@ tr:nth-child(even) td {
 				</a></h3>
 					<?php wp_reset_postdata(); ?>
 			  <?php endif; ?>
-			  <?php the_field( 'phone', $locationId ); ?>
-			  <br />
+			  <?php if (get_field('unstaffed_location', $locationId) == false) {
+					the_field( 'phone', $locationId );
+					print("<br />");
+				}	?>
+			  
 			  <a class="map" href="<?php echo esc_url( $mapPage . $slug ); ?>">Map:&nbsp;
 			  <?php the_field( 'building', $locationId ); ?>
 			  </a>
@@ -363,8 +366,10 @@ endwhile;
 			  
 			  
 			  
-			<?php the_field( 'phone', $locationId ); ?>
-			<br />
+						  <?php if (get_field('unstaffed_location', $locationId) == false) {
+					the_field( 'phone', $locationId );
+					print("<br />");
+				}	?>
 			<a class="map" href="<?php echo esc_url( $mapPage . $slug ); ?>">Map:&nbsp;
 			<?php the_field( 'building', $locationId ); ?>
 			</a>


### PR DESCRIPTION
## Developer
To prepare for Barker to become an unstaffed location we wanted to make some visual updates to our locations template, as well as the homepage hours widget for our libraries.

This work adds a checkbox to the Location Attributes ("Unstaffed location"). When checked, phone numbers are hidden from the location page and homepage widget, small styling tweaks are activated, and the 24/7 study space line is hidden.

https://mitlibraries.atlassian.net/browse/PW-183

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
