### PR TITLE
PW-186: Adjust list styling inside accordions

### DIFF
--- a/web/app/themes/mitlib-parent/css/scss/partials/_accordion.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_accordion.scss
@@ -58,6 +58,8 @@
 			margin-left: 1rem;
 		}
 	}
+
+	div.content > ul {margin-bottom: 0;}
 }
 
 .expandable .content {

--- a/web/app/themes/mitlib-parent/css/scss/partials/_accordion.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_accordion.scss
@@ -50,6 +50,16 @@
 	}
 }
 
+.expandable {
+	ul {
+		li.content {
+			padding-bottom: 0.125rem;
+			padding-left: 0.5rem;
+			margin-left: 1rem;
+		}
+	}
+}
+
 .expandable .content {
 	padding: 0 2em 1em 2.6em;
 	margin-top: 0;

--- a/web/app/themes/mitlib-parent/css/scss/partials/_accordion.scss
+++ b/web/app/themes/mitlib-parent/css/scss/partials/_accordion.scss
@@ -53,7 +53,7 @@
 .expandable {
 	ul {
 		li.content {
-			padding-bottom: 0.125rem;
+			padding-bottom: 0rem;
 			padding-left: 0.5rem;
 			margin-left: 1rem;
 		}

--- a/web/app/themes/mitlib-parent/style.css
+++ b/web/app/themes/mitlib-parent/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib Parent
 Author: MIT Libraries
-Version: 0.10
+Version: 0.11
 Description: The parent theme for the MIT Libraries' Pentagram-designed identity.
 
 */


### PR DESCRIPTION
## Developer
We noticed that the styling of lists inside our accordions included two or three times as much margins/padding as lists on pages that have been typeset.

This work adjusts the spacing to match other pages with ideal spacing.

https://mitlibraries.atlassian.net/browse/PW-186

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
