### PR TITLE
Renames Dewey to E53 Study Space on homepage hours and navigation

### DIFF
--- a/web/app/plugins/mitlib-pull-hours/templates/display-widget-frontpage.php
+++ b/web/app/plugins/mitlib-pull-hours/templates/display-widget-frontpage.php
@@ -19,16 +19,6 @@
 	$this->location_alert( 322 );
 ?>
 <div class="location">
-	<a href="/dewey" aria-labelledby="dewey" class="img-loc dewey"><span class="sr" id="dewey">Dewey Library</span></a>
-	<div class="wrap-loc-info">
-		<h3><a class="name-location" href="/dewey">Dewey Library</a></h3><div class="hours"><span data-location-hours="Dewey Library"></span> today</div><div class="location-info"><a href="/locations/#!dewey-library" class="map-location">E53-100</a><?php if ( get_field("unstaffed_location", 313) == false ) : ?><a href="tel:617-253-5676" class="phone"><span class="number">617-253-5676</span></a><?php endif; ?></div>
-	</div>
-</div>
-<?php
-	// Load location alerts for Dewey (post 313).
-	$this->location_alert( 313 );
-?>
-<div class="location">
 	<a href="/hayden" aria-labelledby="hayden" class="img-loc hayden"><span class="sr" id="hayden">Hayden Library</span></a>
 	<div class="wrap-loc-info">
 		<h3><a class="name-location" href="/hayden">Hayden Library</a></h3><div class="hours"><span data-location-hours="Hayden Library"></span> today</div> <div class="location-info"><a href="/locations/#!hayden-library" class="map-location">14S-100</a><?php if ( get_field("unstaffed_location", 452) == false ) : ?><a href="tel:617-253-5671" class="phone"><span class="number">617-253-5671</span></a><?php endif; ?></div>
@@ -70,5 +60,15 @@
 <?php
 	// Load location alerts for Lewis (post 473).
 	$this->location_alert( 473 );
+?>
+<div class="location">
+	<a href="/dewey" aria-labelledby="dewey" class="img-loc dewey"><span class="sr" id="dewey">E53 Study Space</span></a>
+	<div class="wrap-loc-info">
+		<h3><a class="name-location" href="/dewey">E53 Study Space</a></h3><div class="hours"><span data-location-hours="Dewey Library"></span> today</div><div class="location-info"><a href="/locations/#!dewey-library" class="map-location">E53-100</a><?php if ( get_field("unstaffed_location", 313) == false ) : ?><a href="tel:617-253-5676" class="phone"><span class="number">617-253-5676</span></a><?php endif; ?></div>
+	</div>
+</div>
+<?php
+	// Load location alerts for Dewey (post 313).
+	$this->location_alert( 313 );
 ?>
 <a href="/hours" class="button-primary--green full add-margin link-hours">All hours &amp; locations</a>

--- a/web/app/themes/mitlib-parent/inc/nav-main.php
+++ b/web/app/themes/mitlib-parent/inc/nav-main.php
@@ -49,11 +49,11 @@ namespace Mitlib\Parent;
 					<ul class="list-unbulleted">
 						<li><a href="/hours">Hours and locations home</a></li>
 						<li><a href="/barker">Barker Library</a></li>
-						<li><a href="/dewey">Dewey Library</a></li>
 						<li><a href="/hayden">Hayden Library</a></li>
 						<li><a href="/rotch">Rotch Library</a></li>
 						<li><a href="/distinctive-collections">Distinctive Collections</a></li>
 						<li><a href="/music">Lewis Music Library</a></li>
+						<li><a href="/dewey">E53 Study Space</a></li>
 						<li><a href="/lsa">Library Storage Annex</a></li>
 					</ul>
 				</div>


### PR DESCRIPTION
## Developer
To prepare for the Dewey closure, we'll be renaming the library to E53 Study Space. We want to push this option down on the hours list on the homepage and in the navigation since it's less important to feature now.

This work moves the static references to this library and puts it below Lewis in both locations.

Note: the current "Unstaffed Location" checkbox will remove the phone number and the hours and the hours page will be updated via the hours sheet.

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
