### PR TITLE
Fix hours reference to E53 Study Space

### DIFF
--- a/web/app/plugins/mitlib-pull-hours/templates/display-widget-frontpage.php
+++ b/web/app/plugins/mitlib-pull-hours/templates/display-widget-frontpage.php
@@ -64,7 +64,7 @@
 <div class="location">
 	<a href="/dewey" aria-labelledby="dewey" class="img-loc dewey"><span class="sr" id="dewey">E53 Study Space</span></a>
 	<div class="wrap-loc-info">
-		<h3><a class="name-location" href="/dewey">E53 Study Space</a></h3><div class="hours"><span data-location-hours="Dewey Library"></span> today</div><div class="location-info"><a href="/locations/#!dewey-library" class="map-location">E53-100</a><?php if ( get_field("unstaffed_location", 313) == false ) : ?><a href="tel:617-253-5676" class="phone"><span class="number">617-253-5676</span></a><?php endif; ?></div>
+		<h3><a class="name-location" href="/dewey">E53 Study Space</a></h3><div class="hours"><span data-location-hours="E53 Study Space"></span> today</div><div class="location-info"><a href="/locations/#!dewey-library" class="map-location">E53-100</a><?php if ( get_field("unstaffed_location", 313) == false ) : ?><a href="tel:617-253-5676" class="phone"><span class="number">617-253-5676</span></a><?php endif; ?></div>
 	</div>
 </div>
 <?php


### PR DESCRIPTION
## Developer
When implementing a change to rename and move the Dewey Library below Lewis and rename it E53 Study Space, the `data-location-hours` attribute was never updated to match. This appears to cause the homepage's hours to not pull in the new hours from the spreadsheet on production.

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [x] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
