### PR TITLE
Add support for NLS link to multisearch widget

### DIFF
--- a/web/app/plugins/mitlib-multisearch-widget/class-multisearch-widget.php
+++ b/web/app/plugins/mitlib-multisearch-widget/class-multisearch-widget.php
@@ -119,6 +119,13 @@ class Multisearch_Widget extends \WP_Widget {
 
 		if ( $instance['targets'] == 'use' ) {
 		
+			// Determine whether to enable NLS based on widget settings and the user's cookie.
+			$nls_enabled = $this->readCookie( $instance['nls_default'] );
+
+			$nls_link_toggle = $this->setToggleValue( $nls_enabled );
+
+			$nls_included = $instance['nls_included'];
+
 			echo '<div id="search-all" class="r-tabs-panel r-tabs-state-active use" aria-labelledby="tab-all">';
 				include( $all_template );
 			echo '</div>';
@@ -162,6 +169,11 @@ class Multisearch_Widget extends \WP_Widget {
 		if ( '' == $instance['bento_url'] ) {
 			$bento_url = 'https://lib.mit.edu/';
 		}
+		$nls_default = $instance['nls_default'];
+		if ( '' == $instance['nls_default'] ) {
+			$nls_default = 'off';
+		}
+		$nls_included = $instance['nls_included'];
 		?>
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'banner_text' ) ); ?>">
@@ -233,6 +245,56 @@ class Multisearch_Widget extends \WP_Widget {
 				name="<?php echo esc_attr( $this->get_field_name( 'bento_url' ) ); ?>"
 				value="<?php echo esc_html( $bento_url ); ?>">
 		</p>
+		<h3>Natural language search</h3>
+		<p>
+			Should the natural language option be shown?<br>
+			<label>
+				<input
+					type="checkbox"
+					name="<?php echo esc_attr( $this->get_field_name( 'nls_included' ) ); ?>"
+					value="included"
+						<?php
+						if ( 'included' == $nls_included ) {
+							echo "checked='checked'";
+						}
+						?>
+				>
+				Yes, include this feature.
+			</label>
+		</p>
+		<p>Which is the default query mode?</p>
+		<ul>
+			<li>
+				<label>
+					<input
+					  type="radio"
+						name="<?php echo esc_attr( $this->get_field_name( 'nls_default' ) ); ?>"
+						value="off"
+						<?php
+						if ( 'off' == $nls_default ) {
+							echo "checked='checked'";
+						}
+						?>
+					>
+					Keyword
+				</label>
+			</li>
+			<li>
+				<label>
+					<input
+					  type="radio"
+						name="<?php echo esc_attr( $this->get_field_name( 'nls_default' ) ); ?>"
+						value="on"
+						<?php
+						if ( 'on' == $nls_default ) {
+							echo "checked='checked'";
+						}
+						?>
+					>
+					Natural Language
+				</label>
+			</li>
+		</ul>
 		<?php
 	}
 
@@ -249,7 +311,42 @@ class Multisearch_Widget extends \WP_Widget {
 		$instance['banner_text'] = $new_instance['banner_text'];
 		$instance['targets'] = $new_instance['targets'];
 		$instance['bento_url'] = $new_instance['bento_url'];
+		$instance['nls_default'] = $new_instance['nls_default'];
+		$instance['nls_included'] = $new_instance['nls_included'];
 		return $instance;
+	}
+
+	/**
+	 * ReadCookie looks for the 'nls_enabled' domain cookie in the $_COOKIE
+	 * superglobal. If no value is found, it returns the default value - which is
+	 * defined via the widget settings form.
+	 *
+	 * @param string $nls_enabled Either 'on' (for hybrid) or 'off' (for keyword) - defined in widget settings form.
+	 */
+	private function readCookie( $nls_enabled ) {
+		if ( array_key_exists( 'STYXKEY_nls_enabled', $_COOKIE ) ) {
+			if ( 'true' == $_COOKIE['STYXKEY_nls_enabled'] ) {
+				$nls_enabled = 'on';
+			} else {
+				$nls_enabled = 'off';
+			}
+		}
+
+		return $nls_enabled;
+	}
+
+	/**
+	 * SetToggleValue determines what the state of the toggle value should be if the user decides to activate (or
+	 * deactivate) the natural language feature.
+	 *
+	 * @param string $nls_enabled Either 'on' (for hybrid) or 'off' (for keyword) - by this point defined by readCookie.
+	 */
+	private function setToggleValue( $nls_enabled ) {
+		if ( 'on' == $nls_enabled ) {
+			return 'false';
+		}
+
+		return 'true';
 	}
 
 	/**

--- a/web/app/plugins/mitlib-multisearch-widget/class-multisearch-widget.php
+++ b/web/app/plugins/mitlib-multisearch-widget/class-multisearch-widget.php
@@ -317,9 +317,11 @@ class Multisearch_Widget extends \WP_Widget {
 	}
 
 	/**
-	 * ReadCookie looks for the 'nls_enabled' domain cookie in the $_COOKIE
-	 * superglobal. If no value is found, it returns the default value - which is
-	 * defined via the widget settings form.
+	 * ReadCookie looks for the 'STYXKEY_nls_enabled' domain cookie in the $_COOKIE superglobal. If no value is found, it
+	 * returns the default value - which is defined via the widget settings form. (We use the STYXKEY prefix in the cookie
+	 * name because this is what Pantheon allows to pass through its caching layers).
+	 *
+	 * @see https://docs.pantheon.io/cookies#cache-varying-cookies
 	 *
 	 * @param string $nls_enabled Either 'on' (for hybrid) or 'off' (for keyword) - defined in widget settings form.
 	 */

--- a/web/app/plugins/mitlib-multisearch-widget/mitlib-multisearch-widget.php
+++ b/web/app/plugins/mitlib-multisearch-widget/mitlib-multisearch-widget.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: MITlib Multisearch Widget
  * Description: This plugin provides a widget that provides searches against multiple targets.
- * Version: 1.6.0
+ * Version: 1.7.0
  * Author: MIT Libraries
  * License: GPL2
  *

--- a/web/app/plugins/mitlib-multisearch-widget/templates/tab-all-use.php
+++ b/web/app/plugins/mitlib-multisearch-widget/templates/tab-all-use.php
@@ -34,7 +34,7 @@
 	</div>
 	<?php if ( 'included' == $nls_included ) { ?>
 		<div class="nls-toggle">
-			<a class="toggle <?php echo esc_attr( $nls_enabled ); ?>" href="<?php echo esc_url( 'https://search.libraries.mit.edu/natural_language_search_optin?natural_language_search_optin=' . $nls_link_toggle . '&return_to=/' ); ?>">Try natural language search</a>
+			<a class="toggle <?php echo esc_attr( $nls_enabled ); ?>" href="<?php echo esc_url( 'https://search.libraries.mit.edu/natural_language_search_optin?natural_language_search_optin=' . $nls_link_toggle . '&return_to=/' ); ?>">Natural language search</a>
 			<a class="learn-more" href="https://search.libraries.mit.edu/about-natural-language-search">Learn more</a>
 		</div>
 	<?php } ?>

--- a/web/app/plugins/mitlib-multisearch-widget/templates/tab-all-use.php
+++ b/web/app/plugins/mitlib-multisearch-widget/templates/tab-all-use.php
@@ -7,6 +7,7 @@
  */
 
 ?>
+<!-- nls state: _<?php echo esc_attr( $nls_enabled ); ?>_ -->
 <form
 	class="form search-bento"
 	action="https://search.libraries.mit.edu/results"
@@ -31,8 +32,10 @@
 	<div>
 		<a href="/search-advanced/">Advanced search</a> | <a href="/search/">More ways to search</a>
 	</div>
-	<div class="nls-toggle">
-		<a class="toggle on" href="#">Try natural language search</a>
-		<a class="learn-more" href="https://search.libraries.mit.edu/about-natural-language-search">Learn more</a>
-	</div>
+	<?php if ( 'included' == $nls_included ) { ?>
+		<div class="nls-toggle">
+			<a class="toggle <?php echo esc_attr( $nls_enabled ); ?>" href="https://search.libraries.mit.edu/natural_language_search_optin?natural_language_search_optin=<?php echo esc_attr( $nls_link_toggle ); ?>&return_to=/">Try natural language search</a>
+			<a class="learn-more" href="https://search.libraries.mit.edu/about-natural-language-search">Learn more</a>
+		</div>
+	<?php } ?>
 </div>

--- a/web/app/plugins/mitlib-multisearch-widget/templates/tab-all-use.php
+++ b/web/app/plugins/mitlib-multisearch-widget/templates/tab-all-use.php
@@ -34,7 +34,7 @@
 	</div>
 	<?php if ( 'included' == $nls_included ) { ?>
 		<div class="nls-toggle">
-			<a class="toggle <?php echo esc_attr( $nls_enabled ); ?>" href="https://search.libraries.mit.edu/natural_language_search_optin?natural_language_search_optin=<?php echo esc_attr( $nls_link_toggle ); ?>&return_to=/">Try natural language search</a>
+			<a class="toggle <?php echo esc_attr( $nls_enabled ); ?>" href="<?php echo esc_url( 'https://search.libraries.mit.edu/natural_language_search_optin?natural_language_search_optin=' . $nls_link_toggle . '&return_to=/' ); ?>">Try natural language search</a>
 			<a class="learn-more" href="https://search.libraries.mit.edu/about-natural-language-search">Learn more</a>
 		</div>
 	<?php } ?>


### PR DESCRIPTION
This updates the widget settings form for the Multisearch Widget, adding two new controls (pictured here)

<img width="443" height="227" alt="Screenshot 2026-07-01 at 11 56 04 PM" src="https://github.com/user-attachments/assets/7ecb1a4d-bb1f-46de-b714-fae1c9935287" />

**About this feature**
1. There is an "include this feature" checkbox, which - when set - causes the natural language indicator and link to display. Adding this is a hedge against any unexpected problems on launch day - which I don't think is likely, but I'd like a safety net.
2. There is also a default query mode choice, which determines whether the UI reflects that natural language search is enabled or not for users who have not yet set a cookie value for themselves. **The intent of this setting is that we maintain it in sync with the value defined within Search MIT Libraries.**

The display of the natural language feature is thus meant to be determined along the following lines:
1. If the user has a cookie already defined indicating that they've chosen a mode to use, the UI will adhere to that choice.
2. If the user has no cookie defined, the UI will display according to the field in the widget configuration form.
_(the result of this calculation can _always_ be seen in markup, in an HTML comment that is rendered even if the "include this feature" checkbox is set to "off". I'm including that debugging step as a hedge against having to turn the checkbox off while still troubleshooting what the behavior would be when we enable it again.)_

**About this multidev**
I've configured the multidev in a specific way, to demonstrate a confirmation check that I'll be performing once this gets deployed to production. Details of that, including links to some internal pages demonstrating what's going on, have been added to the Jira ticket: https://mitlibraries.atlassian.net/browse/USE-631

## Developer

Ticket: https://mitlibraries.atlassian.net/browse/USE-631

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.
- [X] No stylesheets have changed.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [X] No secrets have changed.

### Documentation

- [ ] Project documentation has been updated
- [X] No documentation changes are needed

### Accessibility

- [X] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [ ] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
