### PR TITLE
Update security scanning configuration

### DIFF
--- a/phpcs.security.xml
+++ b/phpcs.security.xml
@@ -7,6 +7,7 @@
     <!-- Exclude non-security sniffs -->
     <exclude name="Generic" />
     <exclude name="Modernize" />
+    <exclude name="NormalizedArrays" />
     <exclude name="PEAR" />
     <exclude name="PSR2" />
     <exclude name="Squiz" />


### PR DESCRIPTION
This updates our security-focused PHPCS configuration file to add a new top-level sniff category (NormalizedArrays) from the exclusion list.

Removing this will allow our security-focused tool to remain purely focused on `WordPress.Security.*` checks.