### PR TITLE
Shorten cache lifetime for location pages to 1 hr

### DIFF
--- a/web/app/themes/mitlib-parent/functions.php
+++ b/web/app/themes/mitlib-parent/functions.php
@@ -139,6 +139,8 @@ function override_cache_default_max_age() {
 		return 1 * HOUR_IN_SECONDS;
 	} elseif ( '/exhibits' == $site && is_page( 'current-upcoming-past-exhibits' ) ) { // The exhibits site composite listing.
 		return 1 * HOUR_IN_SECONDS;
+	} elseif ( is_page_template( 'templates/page-location.php' ) || is_page_template( 'templates/page-location-2021.php' ) ) {
+		return 1 * HOUR_IN_SECONDS;
 	} else { // All other content should be cached for a week.
 		return 1 * WEEK_IN_SECONDS;
 	}


### PR DESCRIPTION
** Why are these changes being introduced:

In practice, having location pages last for one week in the cache means that users very rarely see more than one featured expert. We would like users to, as they reload a location page (or visit it more than once) to have a greater probability of seeing different experts.

** Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/pw-188

** How does this address that need:

This adds a branch to the caching logic in the parent theme, resulting in location pages (those using the location or location-2021 templates) to only be cached for one hour - instead of one week.

This change only applies to anonymous users, and authenticated users should already trigger a from-scratch page rendering each time they hit refresh.

** Document any side effects to this change:

Our cache control logic gets yet more complicated, and this is the first time we're checking page templates in the process (previously we have only used is_page() and the $site variable). However, the is_page_template() function is a stable function provided by WordPress so we don't need to rely on any additional trickery.

Additionally, shortening the cache lifetime in this way is not a guarantee that users _will_ see more experts - the logic that selects an expert is liable to repeatedly land on the same expert, and this outcome gets more likely when there are fewer available experts to choose from. When it isn't clear how often users are loading a location page multiple times, I can't say that this will be hugely impactful.

## Developer

### Stylesheets

- [ ] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.
- [x] No stylesheets are changed

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README
- [x] No secrets are impacted

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)
- [x] No a11y changes are implicated

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
