### PR TITLE
Upgrade PHP from 8.2 to 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.4', '8.5']
 
     steps:
     - uses: actions/checkout@v6

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     }
   ],
   "require": {
-    "php": ">=7.4",
+    "php": ">=8.4",
     "composer/installers": "^2.2",
     "connectthink/wp-scss": "^2.4@beta",
     "cweagans/composer-patches": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad12b68caa4cbca755b590c98898fa06",
+    "content-hash": "6e9de2a03ec2353ebe946ee1feae3f49",
     "packages": [
         {
             "name": "ConnectThink/WP-SCSS",
@@ -4645,7 +4645,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4"
+        "php": ">=8.4"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/pantheon.yml
+++ b/pantheon.yml
@@ -7,7 +7,7 @@ web_docroot: true
 # See https://pantheon.io/docs/pantheon-yml/#enforce-https--hsts for valid values.
 enforce_https: transitional
 
-php_version: 8.2
+php_version: 8.4
 
 # See https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb
 database:


### PR DESCRIPTION
This upgrades our version of PHP from 8.2 (leaving security-only update status at the end of the year) to 8.4 (still actively supported, although leaving active support at the end of the year).