### PR TITLE
Upgrade MariaDB to 10.6

### DIFF
--- a/pantheon.yml
+++ b/pantheon.yml
@@ -11,7 +11,7 @@ php_version: 8.2
 
 # See https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb
 database:
-  version: 10.4
+  version: 10.6
 
 build_step: true
 


### PR DESCRIPTION
This is being treated as part of dependency updates - it moves the network from using MariaDB 10.4 to 10.6 (the latest version Pantheon supports)