### PR TITLE
Hook up global alerts for New Homepage using current sitewide alert system

### DIFF
--- a/web/app/themes/mitlib-parent/css/v2/components/alerts.css
+++ b/web/app/themes/mitlib-parent/css/v2/components/alerts.css
@@ -33,7 +33,8 @@
     flex-grow: 1;
     
     i {
-      margin-top: var(--sp-100);
+      font-size: 18px;
+      margin-top: 3px;
       flex-shrink: 0;
       flex-grow: 0;
     }

--- a/web/app/themes/mitlib-parent/css/v2/components/alerts.css
+++ b/web/app/themes/mitlib-parent/css/v2/components/alerts.css
@@ -21,6 +21,8 @@
 #global-alert {
   position: relative;
 
+  &.hidden {display: none;}
+
   .content-wrapper {
     gap: var(--sp-400);
   }

--- a/web/app/themes/mitlib-parent/js/alerts.js
+++ b/web/app/themes/mitlib-parent/js/alerts.js
@@ -1,3 +1,6 @@
+// Check to see if the current page is a v2 page. If it is, we'll use v2 alert markup and load a v2 close button in the respective functions. If not, we'll use v1.
+var isV2page = document.body.classList.contains('v2-page');
+
 // Loads alert-level posts on the top of all pages
 function filterAlerts(posts) {
 	// This processes an array of posts for valid, confirmed, alerts
@@ -56,12 +59,26 @@ function renderAlert(markup,id) {
 }
 
 function setClosable(alert_ID) {
-	// Add a Close icon/svg/button
-	$('.posts--preview--alerts .post').append('<a href="#0" id="close" class="action-close"><span class="sr">Dismiss</span><i class="fa fa-circle-xmark" aria-hidden="true"></i></a>');
-	// On click
+	// Add a Close button. We use v2 markup only for pages that are v2 pages. Otherwise, we'll use v1 markup.
+	if(isV2page) { 
+		// v2 close button markup
+		$('#global-alert').append('<a id="close" href="#" class="dismiss"><i class="fa-sharp fa-light fa-xmark"></i></a>');
+	} else {
+		// v1 close button markup
+		$('.posts--preview--alerts .post').append('<a href="#0" id="close" class="action-close"><span class="sr">Dismiss</span><i class="fa fa-circle-xmark" aria-hidden="true"></i></a>');
+	}
+
+	// On click of the link with the close id
 	$('#close').click(function(){
-		// Add the necessary transition hide class
-		$(this).closest('.posts--preview--alerts').addClass('transition-vertical--hide');
+		
+		// Apply relevant logic based on v1 or v2 alert. Add relevant class to hide the alert.
+		if(isV2page) { 
+			// v2
+			$(this).closest('#global-alert').addClass('hidden');
+		} else {
+			// v1
+			$(this).closest('.posts--preview--alerts').addClass('transition-vertical--hide');
+		}
 		// Bump the hours calendar down, if it is present.
 		moveCalendar(-152);
 		// If localStorage
@@ -92,15 +109,32 @@ function showAlerts(json) {
 		// Check for empty title
 		alert_title = ('' === alert_posts_arr[i].title.rendered) ? 'Alert!' : alert_posts_arr[i].title.rendered;
 
-		// Alert HTML template
-		alert_template = '<div class="posts--preview--alerts transition-vertical transition-vertical--hide">' +
-			'<div class="post alert--critical flex-container">' +
-				'<i class="fa fa-circle-exclamation" aria-hidden="true"></i>' +
-				'<div class="content-post alertText">' +
-					'<h3>' + alert_title + '</h3> ' + alert_posts_arr[i].content.rendered +
+		// If this is a v2 page, use the v2 alert markup. Otherwise, use the v1 markup.
+		if (isV2page) {
+			// Alert HTML template (v2)
+			alert_template = '<section id="global-alert">' + 
+				'<div class="content-wrapper">' + 
+					'<div class="global-alert-message">' + 
+						'<i class="fa-solid fa-triangle-exclamation"></i>' +
+						'<header>' +
+							'<h2>' + alert_title + '</h2>' +
+							'<p>' + alert_posts_arr[i].content.rendered + '</p>' +
+						'</header>' +
+					'</div>' +
+				'</div>'
+			'</section>';						
+
+		} else {
+			// Alert HTML template (v1)
+			alert_template = '<div class="posts--preview--alerts transition-vertical transition-vertical--hide">' +
+				'<div class="post alert--critical flex-container">' +
+					'<i class="fa fa-circle-exclamation" aria-hidden="true"></i>' +
+					'<div class="content-post alertText">' +
+						'<h3>' + alert_title + '</h3> ' + alert_posts_arr[i].content.rendered +
+					'</div>' +
 				'</div>' +
-			'</div>' +
-		'</div>';
+			'</div>';
+		}
 
 		renderAlert(alert_template,alert_ID);
 

--- a/web/app/themes/mitlib-parent/style.css
+++ b/web/app/themes/mitlib-parent/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib Parent
 Author: MIT Libraries
-Version: 0.12
+Version: 0.13
 Description: The parent theme for the MIT Libraries' Pentagram-designed identity.
 
 */


### PR DESCRIPTION
## Developer
This work connects the sitewide alert system that currently exists to use the new global alert style we introduced as a placeholder template for the new homepage.

Note: the intended behavior here is that for any v2 page (which is currently ONLY the new homepage) the alerts would be styled using the global alert banner pattern. For any other page it will use the current v1 system instead. Both are hooked up to the same post and local storage to remember dismissing should work for both.

To get this to render, this work introduces if statements based on a bool when a page has the `v2-page` class in the body. These checks are used to change between v1 and v2 versions for the logic to:
* Render the alert template
* Render the close button with the correct markup
* Set local storage and close the alert

Relevant ticket:
https://mitlibraries.atlassian.net/browse/LHNU-238

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
