### PR TITLE
LNHU-229: Dynamic events feed with manual overrides for new homepage

### DIFF
--- a/web/app/mu-plugins/mitlib-post/data/sitenews/group_55101c53c2d37.json
+++ b/web/app/mu-plugins/mitlib-post/data/sitenews/group_55101c53c2d37.json
@@ -101,6 +101,33 @@
             "maxlength": 8
         },
         {
+            "key": "field_66bc0a1e2f4d1",
+            "label": "Event Location",
+            "name": "event_location",
+            "type": "text",
+            "instructions": "Enter the event location.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_53ecc2067d32f",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
+        },
+        {
             "key": "field_5a2a9ca90a81c",
             "label": "Calendar URL",
             "name": "calendar_url",

--- a/web/app/mu-plugins/mitlib-post/data/sitenews/group_55101c54091f3-1.json
+++ b/web/app/mu-plugins/mitlib-post/data/sitenews/group_55101c54091f3-1.json
@@ -23,6 +23,33 @@
             "maxlength": "",
             "readonly": 0,
             "disabled": 0
+        },
+        {
+            "key": "field_66bd1a3f5c9e2",
+            "label": "Pin event on homepage",
+            "name": "pin_event_on_homepage",
+            "type": "true_false",
+            "instructions": "This event will be pinned on the events section of the Libraries' homepage.",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_53ecc2067d32f",
+                        "operator": "==",
+                        "value": "1"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "message": "",
+            "default_value": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
         }
     ],
     "location": [

--- a/web/app/plugins/mitlib-pull-events/class-pull-events-plugin.php
+++ b/web/app/plugins/mitlib-pull-events/class-pull-events-plugin.php
@@ -135,6 +135,15 @@ class Pull_Events_Plugin {
 				if ( isset( $val['event']['photo_url'] ) ) {
 					$photo_url = $val['event']['photo_url'];
 				}
+				$event_location = '';
+				if ( ! empty( $val['event']['location_name'] ) ) {
+					$event_location = $val['event']['location_name'];
+					if ( ! empty( $val['event']['room_number'] ) ) {
+						$event_location .= ', ' . $val['event']['room_number'];
+					}
+				} elseif ( isset( $val['event']['experience'] ) && in_array( $val['event']['experience'], array( 'virtual', 'hybrid' ), true ) ) {
+					$event_location = 'Virtual Event';
+				}
 				$category = 43;  // TODO: Make this user-configurable. This is the Category ID value in the News site for the "All News" value.
 
 				if ( isset( $calendar_id ) ) {
@@ -209,6 +218,7 @@ class Pull_Events_Plugin {
 					self::wrap_update_post_meta( $post_id, 'calendar_url', $calendar_url );
 					self::wrap_update_post_meta( $post_id, 'calendar_id', $calendar_id );
 					self::wrap_update_post_meta( $post_id, 'calendar_image', $photo_url );
+					self::wrap_update_post_meta( $post_id, 'event_location', $event_location );
 
 				}
 			}

--- a/web/app/themes/mitlib-parent/css/v2/pages/home.css
+++ b/web/app/themes/mitlib-parent/css/v2/pages/home.css
@@ -730,10 +730,22 @@ section#todays-hours {
         }
 
         .event-day {
-          padding: var(--sp-200) var(--sp-300);
+          padding: 0 var(--sp-300) 0;
           font-size: var(--font-size-2xl);
           font-weight: var(--font-weight-bold);
+          border-bottom: 1px solid var(--color-gray-300);
+          width: 100%;
+          text-align: center;
         }
+
+        .event-weekday {
+          padding: var(--sp-100) 0;
+          text-transform: uppercase;
+          font-size: var(--font-size-xs);
+          font-weight: var(--font-weight-medium);
+          letter-spacing: 0.05em;          
+        }
+
       }
     }
   }

--- a/web/app/themes/mitlib-parent/style.css
+++ b/web/app/themes/mitlib-parent/style.css
@@ -1,7 +1,7 @@
 /*
 Theme Name: MITlib Parent
 Author: MIT Libraries
-Version: 0.13
+Version: 0.14
 Description: The parent theme for the MIT Libraries' Pentagram-designed identity.
 
 */

--- a/web/app/themes/mitlib-parent/templates/page-home-v2.php
+++ b/web/app/themes/mitlib-parent/templates/page-home-v2.php
@@ -216,7 +216,7 @@ get_header( 'v2' ); ?>
 						'orderby'             => 'meta_value',
 						'meta_key'            => 'event_date',
 						'order'               => 'ASC',
-						'ignore_sticky_posts' => 1, // Exclude sticky news posts
+						'ignore_sticky_posts' => 1, // Prevents sticky posts from being pushed to the top of the order
 						'meta_query'          => array( // Ensures that the event date is today or later
 							array(
 								'key'     => 'event_date', 
@@ -254,7 +254,9 @@ get_header( 'v2' ); ?>
 								'url'        => ! empty( $custom['calendar_url'][0] ) ? $custom['calendar_url'][0] : get_the_permalink(),
 								'event_date' => $event_date_raw,
 								'start_time' => isset( $custom['event_start_time'][0] ) ? $custom['event_start_time'][0] : '',
-								'end_time'   => isset( $custom['event_end_time'][0] ) ? $custom['event_end_time'][0] : '',										'location'   => isset( $custom['event_location'][0] ) ? $custom['event_location'][0] : '',								'excerpt'    => get_the_excerpt(),
+								'end_time'   => isset( $custom['event_end_time'][0] ) ? $custom['event_end_time'][0] : '',										
+								'location'   => isset( $custom['event_location'][0] ) ? $custom['event_location'][0] : '',								
+								'excerpt'    => get_the_excerpt(),
 							);
 
 							// Bucket into pinned (pin_event_on_homepage) vs regular.

--- a/web/app/themes/mitlib-parent/templates/page-home-v2.php
+++ b/web/app/themes/mitlib-parent/templates/page-home-v2.php
@@ -217,10 +217,10 @@ get_header( 'v2' ); ?>
 						'meta_key'            => 'event_date',
 						'order'               => 'ASC',
 						'ignore_sticky_posts' => 1, // Exclude sticky news posts
-						'meta_query'          => array(
+						'meta_query'          => array( // Ensures that the event date is today or later
 							array(
-								'key'     => 'event_date', // Checks for the "Is event" checkbox being true
-								'value'   => $today, // Ensures that the event date is today or later
+								'key'     => 'event_date', 
+								'value'   => $today, 
 								'compare' => '>=',
 							),
 						),
@@ -235,7 +235,7 @@ get_header( 'v2' ); ?>
 					if ( $events_query->have_posts() ) :
 						while ( $events_query->have_posts() ) :
 							$events_query->the_post();
-							$custom = get_post_custom();
+							$custom = get_post_custom(); // store custom fields for this post in an array
 
 							// Skip non-event posts (is_event checkbox unchecked).
 							if ( ! isset( $custom['is_event'][0] ) || $custom['is_event'][0] !== '1' ) {
@@ -257,8 +257,8 @@ get_header( 'v2' ); ?>
 								'end_time'   => isset( $custom['event_end_time'][0] ) ? $custom['event_end_time'][0] : '',										'location'   => isset( $custom['event_location'][0] ) ? $custom['event_location'][0] : '',								'excerpt'    => get_the_excerpt(),
 							);
 
-							// Bucket into featured (featuredArticle = True) vs regular.
-							if ( ! empty( $custom['featuredArticle'][0] ) && $custom['featuredArticle'][0] === 'True' ) {
+							// Bucket into pinned (pin_event_on_homepage) vs regular.
+							if ( ! empty( $custom['pin_event_on_homepage'][0] ) && $custom['pin_event_on_homepage'][0] === '1' ) {
 								$featured_events[] = $event_data;
 							} else {
 								$regular_events[] = $event_data;
@@ -300,7 +300,7 @@ get_header( 'v2' ); ?>
 								<span class="event-weekday"><?php echo esc_html( $event_dt ? $event_dt->format( 'D' ) : '' ); ?></span>
 							</div>
 							<div class="event-details">
-								<h3><a href="<?php echo esc_url( $event['url'] ); ?>"><?php echo esc_html( $event['title'] ); ?></a></h3>
+								<h3><a href="<?php echo esc_url( $event['url'] ); ?>"><?php echo esc_html( mb_strimwidth( $event['title'], 0, 75, '…' ) ); ?></a></h3>
 								<p><?php echo esc_html( $event['excerpt'] ); ?></p>
 								<?php if ( $time_display || $event['location'] ) : ?>
 								<div class="event-metadata">

--- a/web/app/themes/mitlib-parent/templates/page-home-v2.php
+++ b/web/app/themes/mitlib-parent/templates/page-home-v2.php
@@ -289,9 +289,9 @@ get_header( 'v2' ); ?>
 
 						$time_display = '';
 						if ( $event['start_time'] ) {
-							$time_display = esc_html( $event['start_time'] );
+							$time_display = $event['start_time'];
 							if ( $event['end_time'] ) {
-								$time_display .= ' &#150; ' . esc_html( $event['end_time'] );
+								$time_display .= ' &#150; ' . $event['end_time'];
 							}
 						}
 						?>
@@ -307,7 +307,7 @@ get_header( 'v2' ); ?>
 								<?php if ( $time_display || $event['location'] ) : ?>
 								<div class="event-metadata">
 									<?php if ( $time_display ) : ?>
-									<span class="event-time"><i class="fa-light fa-clock" role="img" aria-label="Event time"></i><?php echo wp_kses_post( $time_display ); ?></span>
+									<span class="event-time"><i class="fa-light fa-clock" role="img" aria-label="Event time"></i><?php echo wp_kses( $time_display, array() ); ?></span>
 									<?php endif; ?>
 									<?php if ( $event['location'] ) : ?>
 									<span class="event-location"><i class="fa-light fa-map-pin" role="img" aria-label="Event location"></i><?php echo esc_html( $event['location'] ); ?></span>

--- a/web/app/themes/mitlib-parent/templates/page-home-v2.php
+++ b/web/app/themes/mitlib-parent/templates/page-home-v2.php
@@ -247,8 +247,7 @@ get_header( 'v2' ); ?>
 								'url'        => ! empty( $custom['calendar_url'][0] ) ? $custom['calendar_url'][0] : get_the_permalink(),
 								'event_date' => $event_date_raw,
 								'start_time' => isset( $custom['event_start_time'][0] ) ? $custom['event_start_time'][0] : '',
-								'end_time'   => isset( $custom['event_end_time'][0] ) ? $custom['event_end_time'][0] : '',
-								'excerpt'    => get_the_excerpt(),
+								'end_time'   => isset( $custom['event_end_time'][0] ) ? $custom['event_end_time'][0] : '',										'location'   => isset( $custom['event_location'][0] ) ? $custom['event_location'][0] : '',								'excerpt'    => get_the_excerpt(),
 							);
 
 							if ( ! empty( $custom['featuredArticle'][0] ) && $custom['featuredArticle'][0] === 'True' ) {
@@ -294,9 +293,14 @@ get_header( 'v2' ); ?>
 							<div class="event-details">
 								<h3><a href="<?php echo esc_url( $event['url'] ); ?>"><?php echo esc_html( $event['title'] ); ?></a></h3>
 								<p><?php echo esc_html( $event['excerpt'] ); ?></p>
-								<?php if ( $time_display ) : ?>
+								<?php if ( $time_display || $event['location'] ) : ?>
 								<div class="event-metadata">
+									<?php if ( $time_display ) : ?>
 									<span class="event-time"><i class="fa-light fa-clock" role="img" aria-label="Event time"></i><?php echo $time_display; ?></span>
+									<?php endif; ?>
+									<?php if ( $event['location'] ) : ?>
+									<span class="event-location"><i class="fa-light fa-map-pin" role="img" aria-label="Event location"></i><?php echo esc_html( $event['location'] ); ?></span>
+									<?php endif; ?>
 								</div>
 								<?php endif; ?>
 							</div>

--- a/web/app/themes/mitlib-parent/templates/page-home-v2.php
+++ b/web/app/themes/mitlib-parent/templates/page-home-v2.php
@@ -194,34 +194,118 @@ get_header( 'v2' ); ?>
 					</div>
 					<a class="button secondary" href="https://libraries.mit.edu/news/events/">See all events</a>
 				</div>
-				<div class="event">
-					<div class="event-date">
-						<span class="event-month">Aug</span>
-						<span class="event-day">24</span>
-					</div>
-					<div class="event-details">
-						<h3><a href="https://calendar.mit.edu/event/carpentriesmit-introduction-to-programming-with-python">Carpentries@MIT Introduction to Programming with Python</a></h3>
-						<p>A beginner-friendly workshop combining short tutorials with hands-on exercises</p>
-						<div class="event-metadata">
-							<span class="event-time"><i class="fa-light fa-clock" role="img" aria-label="Event time"></i>10:00 am &#150; 4:00 pm</span>
-							<span class="event-location"><i class="fa-light fa-map-pin" role="img" aria-label="Event location"></i>Virtual Event</span>
-						</div>		
-					</div>			
-				</div>
-				<div class="event">
-					<div class="event-date">
-						<span class="event-month">Sep</span>
-						<span class="event-day">2</span>
-					</div>
-					<div class="event-details">
-						<h3><a href="https://calendar.mit.edu/event/mit-libraries-resources-and-services-for-graduate-students-6074">MIT Libraries: Resources and Services for Graduate Students</a></h3>
-						<p>How to find the information and data you'll need</p>
-						<div class="event-metadata">
-							<span class="event-time"><i class="fa-light fa-clock" role="img" aria-label="Event time"></i>10:45 &#150; 11:45 am</span>
-							<span class="event-location"><i class="fa-light fa-map-pin" role="img" aria-label="Event location"></i>Building 14, S-130 (The Nexus)</span>
-						</div>		
-					</div>			
-				</div>
+
+				<?php 
+					// Get the News Site blog ID
+					$news_site_id = 4;
+
+					// Switch to the News Site
+					switch_to_blog( $news_site_id );
+
+					// Get today's date in the format ACF uses
+					$today = date( 'Ymd' );
+
+					$events_args = array(
+						'posts_per_page'      => 20,
+						'post_type'           => 'post',
+						'post_status'         => 'publish',
+						'orderby'             => 'meta_value',
+						'meta_key'            => 'event_date',
+						'order'               => 'ASC',
+						'ignore_sticky_posts' => 1,
+						'meta_query'          => array(
+							array(
+								'key'     => 'event_date',
+								'value'   => $today,
+								'compare' => '>=',
+							),
+						),
+					);
+
+					$events_query = new \WP_Query( $events_args );
+
+					// Separate upcoming events into featured and non-featured
+					$featured_events = array();
+					$regular_events  = array();
+
+					if ( $events_query->have_posts() ) :
+						while ( $events_query->have_posts() ) :
+							$events_query->the_post();
+							$custom = get_post_custom();
+
+							if ( ! isset( $custom['is_event'][0] ) || $custom['is_event'][0] !== '1' ) {
+								continue;
+							}
+
+							$event_date_raw = isset( $custom['event_date'][0] ) ? $custom['event_date'][0] : '';
+							if ( ! $event_date_raw || $event_date_raw < $today ) {
+								continue;
+							}
+
+							$event_data = array(
+								'title'      => ! empty( $custom['homepage_post_title'][0] ) ? $custom['homepage_post_title'][0] : get_the_title(),
+								'url'        => ! empty( $custom['calendar_url'][0] ) ? $custom['calendar_url'][0] : get_the_permalink(),
+								'event_date' => $event_date_raw,
+								'start_time' => isset( $custom['event_start_time'][0] ) ? $custom['event_start_time'][0] : '',
+								'end_time'   => isset( $custom['event_end_time'][0] ) ? $custom['event_end_time'][0] : '',
+								'excerpt'    => get_the_excerpt(),
+							);
+
+							if ( ! empty( $custom['featuredArticle'][0] ) && $custom['featuredArticle'][0] === 'True' ) {
+								$featured_events[] = $event_data;
+							} else {
+								$regular_events[] = $event_data;
+							}
+						endwhile;
+						wp_reset_postdata();
+					endif;
+
+					// Pick display set: featured priority, fill with regular
+					if ( count( $featured_events ) >= 2 ) {
+						$display_events = array_slice( $featured_events, 0, 2 );
+					} elseif ( count( $featured_events ) === 1 ) {
+						$display_events = array_merge( $featured_events, array_slice( $regular_events, 0, 1 ) );
+						usort( $display_events, function( $a, $b ) {
+							return strcmp( $a['event_date'], $b['event_date'] );
+						} );
+					} else {
+						$display_events = array_slice( $regular_events, 0, 2 );
+					}
+
+					foreach ( $display_events as $event ) :
+						$event_dt = \DateTime::createFromFormat( 'Ymd', $event['event_date'] );
+						$event_month = $event_dt ? $event_dt->format( 'M' ) : '';
+						$event_day   = $event_dt ? $event_dt->format( 'j' ) : '';
+
+						$time_display = '';
+						if ( $event['start_time'] ) {
+							$time_display = esc_html( $event['start_time'] );
+							if ( $event['end_time'] ) {
+								$time_display .= ' &#150; ' . esc_html( $event['end_time'] );
+							}
+						}
+						?>
+						<div class="event">
+							<div class="event-date">
+								<span class="event-month"><?php echo esc_html( $event_month ); ?></span>
+								<span class="event-day"><?php echo esc_html( $event_day ); ?></span>
+								<span class="event-weekday"><?php echo esc_html( $event_dt ? $event_dt->format( 'D' ) : '' ); ?></span>
+							</div>
+							<div class="event-details">
+								<h3><a href="<?php echo esc_url( $event['url'] ); ?>"><?php echo esc_html( $event['title'] ); ?></a></h3>
+								<p><?php echo esc_html( $event['excerpt'] ); ?></p>
+								<?php if ( $time_display ) : ?>
+								<div class="event-metadata">
+									<span class="event-time"><i class="fa-light fa-clock" role="img" aria-label="Event time"></i><?php echo $time_display; ?></span>
+								</div>
+								<?php endif; ?>
+							</div>
+						</div>
+						<?php
+					endforeach;
+
+					restore_current_blog();
+				?>
 			</div>			
 		</div>
 	</section>

--- a/web/app/themes/mitlib-parent/templates/page-home-v2.php
+++ b/web/app/themes/mitlib-parent/templates/page-home-v2.php
@@ -195,14 +195,18 @@ get_header( 'v2' ); ?>
 					<a class="button secondary" href="https://libraries.mit.edu/news/events/">See all events</a>
 				</div>
 
-				<?php 
-					// Get the News Site blog ID
+				<?php
+					/* 
+					*  EVENTS LOGIC
+					*  This logic pulls the next two upcoming events from the News site and displays them on the homepage.
+					*  This respects the "Featured on homepage" radio button, making sure those posts are prioritized.
+					*/
+				
+					// Switch to the News site (blog 4) to query event posts.
 					$news_site_id = 4;
-
-					// Switch to the News Site
 					switch_to_blog( $news_site_id );
 
-					// Get today's date in the format ACF uses
+					// Query upcoming posts that have an event_date, sorted soonest-first.
 					$today = date( 'Ymd' );
 
 					$events_args = array(
@@ -212,11 +216,11 @@ get_header( 'v2' ); ?>
 						'orderby'             => 'meta_value',
 						'meta_key'            => 'event_date',
 						'order'               => 'ASC',
-						'ignore_sticky_posts' => 1,
+						'ignore_sticky_posts' => 1, // Exclude sticky news posts
 						'meta_query'          => array(
 							array(
-								'key'     => 'event_date',
-								'value'   => $today,
+								'key'     => 'event_date', // Checks for the "Is event" checkbox being true
+								'value'   => $today, // Ensures that the event date is today or later
 								'compare' => '>=',
 							),
 						),
@@ -224,7 +228,7 @@ get_header( 'v2' ); ?>
 
 					$events_query = new \WP_Query( $events_args );
 
-					// Separate upcoming events into featured and non-featured
+					// Loop through results, filter to is_event posts, and bucket into featured vs regular.
 					$featured_events = array();
 					$regular_events  = array();
 
@@ -233,15 +237,18 @@ get_header( 'v2' ); ?>
 							$events_query->the_post();
 							$custom = get_post_custom();
 
+							// Skip non-event posts (is_event checkbox unchecked).
 							if ( ! isset( $custom['is_event'][0] ) || $custom['is_event'][0] !== '1' ) {
 								continue;
 							}
 
+							// Skip events with no date or a past date.
 							$event_date_raw = isset( $custom['event_date'][0] ) ? $custom['event_date'][0] : '';
 							if ( ! $event_date_raw || $event_date_raw < $today ) {
 								continue;
 							}
 
+							// Build event data array, preferring homepage overrides for title and URL.
 							$event_data = array(
 								'title'      => ! empty( $custom['homepage_post_title'][0] ) ? $custom['homepage_post_title'][0] : get_the_title(),
 								'url'        => ! empty( $custom['calendar_url'][0] ) ? $custom['calendar_url'][0] : get_the_permalink(),
@@ -250,6 +257,7 @@ get_header( 'v2' ); ?>
 								'end_time'   => isset( $custom['event_end_time'][0] ) ? $custom['event_end_time'][0] : '',										'location'   => isset( $custom['event_location'][0] ) ? $custom['event_location'][0] : '',								'excerpt'    => get_the_excerpt(),
 							);
 
+							// Bucket into featured (featuredArticle = True) vs regular.
 							if ( ! empty( $custom['featuredArticle'][0] ) && $custom['featuredArticle'][0] === 'True' ) {
 								$featured_events[] = $event_data;
 							} else {
@@ -259,7 +267,7 @@ get_header( 'v2' ); ?>
 						wp_reset_postdata();
 					endif;
 
-					// Pick display set: featured priority, fill with regular
+					// Pick 2 events to display: prefer featured, backfill with regular, keep date order.
 					if ( count( $featured_events ) >= 2 ) {
 						$display_events = array_slice( $featured_events, 0, 2 );
 					} elseif ( count( $featured_events ) === 1 ) {
@@ -271,6 +279,7 @@ get_header( 'v2' ); ?>
 						$display_events = array_slice( $regular_events, 0, 2 );
 					}
 
+					// Render each event card with date, title, excerpt, time, and location.
 					foreach ( $display_events as $event ) :
 						$event_dt = \DateTime::createFromFormat( 'Ymd', $event['event_date'] );
 						$event_month = $event_dt ? $event_dt->format( 'M' ) : '';
@@ -308,7 +317,7 @@ get_header( 'v2' ); ?>
 						<?php
 					endforeach;
 
-					restore_current_blog();
+					restore_current_blog(); // returns from the News site to current for future queries
 				?>
 			</div>			
 		</div>

--- a/web/app/themes/mitlib-parent/templates/page-home-v2.php
+++ b/web/app/themes/mitlib-parent/templates/page-home-v2.php
@@ -305,7 +305,7 @@ get_header( 'v2' ); ?>
 								<?php if ( $time_display || $event['location'] ) : ?>
 								<div class="event-metadata">
 									<?php if ( $time_display ) : ?>
-									<span class="event-time"><i class="fa-light fa-clock" role="img" aria-label="Event time"></i><?php echo $time_display; ?></span>
+									<span class="event-time"><i class="fa-light fa-clock" role="img" aria-label="Event time"></i><?php echo wp_kses_post( $time_display ); ?></span>
 									<?php endif; ?>
 									<?php if ( $event['location'] ) : ?>
 									<span class="event-location"><i class="fa-light fa-map-pin" role="img" aria-label="Event location"></i><?php echo esc_html( $event['location'] ); ?></span>


### PR DESCRIPTION
## Developer
To avoid needing constant manual editing, we want a dynamic feed of upcoming events from the News site. We also want to ensure the editor can prioritize specific events over others that may be next in the upcoming list.

This work:
* Adds event location to the harvester logic
* Dynamically displays the next two upcoming events
* Uses post excerpt for event description (required by editor)
* Respects the existing "Homepage post title" field to allow manual override of title
* Introduces a new ACF checkbox to pin the event to the homepage
* Logic for pinning will override the next upcoming event with a pinned one while preserving date order
* CSS tweaks to also add the day of the week to the calendar display in the event card

**New checkbox in events editing UI and post title override field**
<img width="529" height="214" alt="Screenshot 2026-08-14 at 11 09 49 AM" src="https://github.com/user-attachments/assets/ba3902ae-2f86-4428-bb57-b7905906b8da" />

**Intended display of Event card when title override is applied and excerpt is present**
<img width="1209" height="337" alt="Screenshot 2026-08-14 at 11 10 39 AM" src="https://github.com/user-attachments/assets/6f7b3544-4816-49ff-986c-d5550bf66add" />


### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [ ] No documentation changes are needed

### Accessibility

- [ ] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
