### PR TITLE
LNHU-265: Copy and style tweaks to v1 search widget form

### DIFF
--- a/web/app/plugins/mitlib-multisearch-widget/class-multisearch-widget.php
+++ b/web/app/plugins/mitlib-multisearch-widget/class-multisearch-widget.php
@@ -59,7 +59,7 @@ class Multisearch_Widget extends \WP_Widget {
 			'multisearch-tabs',
 			plugin_dir_url( __FILE__ ) . 'mitlib-multisearch-widget.css',
 			array(),
-			'1.8.0'
+			'1.9.0'
 		);
 		wp_enqueue_style( 'multisearch-tabs' );
 

--- a/web/app/plugins/mitlib-multisearch-widget/mitlib-multisearch-widget.css
+++ b/web/app/plugins/mitlib-multisearch-widget/mitlib-multisearch-widget.css
@@ -154,13 +154,13 @@
 }
 .r-tabs .button-search {
 	-webkit-appearance: none;
-	transition: background-color .25s, border .25s;
-	border: 1px solid #000;
-	border-radius: 3px;
+	border-radius: 0;
+	border: none;
 	padding: 5px 10px;
-	background-color: #000;
+	background-color: #e50000;
 	background-image: none;
 	font-size: 1rem;
+	box-shadow: none;
 	color: #fff;
 }
 .r-tabs .button-search:hover, 

--- a/web/app/plugins/mitlib-multisearch-widget/templates/tab-all-use.php
+++ b/web/app/plugins/mitlib-multisearch-widget/templates/tab-all-use.php
@@ -12,7 +12,7 @@
 	action="https://search.libraries.mit.edu/results"
 	method="get"
 	data-target="bento">
-	<label for="searchinput-bento">Search the MIT Libraries</label>
+	<label for="searchinput-bento">Search for books, articles, library services, and more</label>
 	<div class="wrap-flex">
 		<div class="flex-left">
 			<input
@@ -20,7 +20,7 @@
 				type="text"
 				id="searchinput-bento"
 				name="q"
-				placeholder="Search across collections, services, and website content">
+				placeholder="Try a citation, topic, database, etc.">
 		</div>
 		<div class="flex-right">
 			<input class="button button-search" type="submit" value="Search">
@@ -29,7 +29,7 @@
 </form>
 <div class="search-option-links">
 	<div>
-		<a href="/search-advanced/">Advanced search</a> | <a href="/search/">More ways to search</a>
+		<a href="/search-advanced/">Advanced search</a>
 	</div>
 	<?php if ( 'included' == $nls_included ) { ?>
 		<div class="nls-toggle">


### PR DESCRIPTION
## Developer
Now that we've switched our homepage's search form copy, we want to mirror that on the v1 version. This work:
* Updates the label and placeholder strings to match SML and homepage
* Updates the search button to Red when enabled to match SML and homepage search buttons.

I noticed the v2 widget search button does not have a disabled state to match the v1's behavior, and added that to a future ticket.

https://mitlibraries.atlassian.net/browse/LHNU-265

### Stylesheets

- [x] Any theme or plugin whose stylesheets have changed has had its version
      string incremented.

### Secrets

- [ ] All new secrets have been added to Pantheon tiers
- [ ] Relevant secrets have been updated in Github Actions
- [ ] All new secrets documented in README

### Documentation

- [ ] Project documentation has been updated
- [x] No documentation changes are needed

### Accessibility

- [x] ANDI or Wave has been run in accordance to
      [our guide](https://mitlibraries.github.io/guides/basics/a11y.html) and
      all issues introduced by these changes have been resolved or opened as new
      issues (link to those issues in the Pull Request details above)

### Stakeholder approval

- [x] Stakeholder approval has been confirmed
- [ ] Stakeholder approval is not needed

### Dependencies

YES | NO dependencies are updated


## Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] The changes have been verified
- [ ] The documentation has been updated or is unnecessary
- [ ] New dependencies are appropriate or there were no changes
